### PR TITLE
vpn: Remove onchanged handler

### DIFF
--- a/internal/vpn.go
+++ b/internal/vpn.go
@@ -87,7 +87,6 @@ func updateConfig(app *App, pubkey string) error {
 			ConfigFileReq{
 				Name:        "wireguard-client",
 				Unencrypted: true,
-				OnChanged:   []string{"/usr/bin/factory-config-vpn"},
 				Value:       updated,
 			},
 		},


### PR DESCRIPTION
This was pointing at an invalid path and isn't needed for
initialization. Its not until fioctl *enables* wireguard that the
handler is needed and fioctl sets the handler for that.

Signed-off-by: Andy Doan <andy@foundries.io>