### PR TITLE
app: Open/Close pkcs11 session between intervals

### DIFF
--- a/internal/ecies.go
+++ b/internal/ecies.go
@@ -11,11 +11,12 @@ import (
 
 type EciesCrypto struct {
 	PrivKey PrivateKey
+	ctx     *crypto11.Context
 }
 
 func NewEciesLocalHandler(privKey crypto.PrivateKey) CryptoHandler {
 	if ec, ok := privKey.(*ecdsa.PrivateKey); ok {
-		return &EciesCrypto{ImportECDSA(ec)}
+		return &EciesCrypto{ImportECDSA(ec), nil}
 	}
 	return nil
 }
@@ -32,6 +33,12 @@ func (ec *EciesCrypto) Decrypt(value string) ([]byte, error) {
 	return decrypted, nil
 }
 
+func (ec *EciesCrypto) Close() {
+	if ec.ctx != nil {
+		ec.ctx.Close()
+	}
+}
+
 func NewEciesPkcs11Handler(ctx *crypto11.Context, privKey crypto11.Signer) CryptoHandler {
-	return &EciesCrypto{ImportPcks11(ctx, privKey)}
+	return &EciesCrypto{ImportPcks11(ctx, privKey), ctx}
 }

--- a/internal/vpn.go
+++ b/internal/vpn.go
@@ -56,7 +56,7 @@ func generateKey(privKeyPath string) (string, error) {
 
 }
 
-func updateConfig(app *App, pubkey string) error {
+func updateConfig(app *App, client *http.Client, pubkey string) error {
 	updated := ""
 	content, err := ioutil.ReadFile(filepath.Join(app.SecretsDir, "wireguard-client"))
 	if err != nil {
@@ -100,7 +100,7 @@ func updateConfig(app *App, pubkey string) error {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	res, err := app.client.Do(req)
+	res, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("Unable to update: %s - %v", app.configUrl, err)
 	}
@@ -112,7 +112,7 @@ func updateConfig(app *App, pubkey string) error {
 	return nil
 }
 
-func initVpn(app *App) error {
+func initVpn(app *App, client *http.Client, crypto CryptoHandler) error {
 	sotaConfig := filepath.Dir(app.EncryptedConfig)
 	wgPriv := filepath.Join(sotaConfig, "wg-priv")
 	if _, err := os.Stat(wgPriv); os.IsNotExist(err) {
@@ -122,7 +122,7 @@ func initVpn(app *App) error {
 			return fmt.Errorf("Unable to generate private key: %s", err)
 		}
 		log.Printf("Uploading Wireguard pub key(%s).", pub)
-		if err := updateConfig(app, pub); err != nil {
+		if err := updateConfig(app, client, pub); err != nil {
 			os.Remove(wgPriv)
 			return fmt.Errorf("Unable to server config with VPN public key: %s", err)
 		}


### PR DESCRIPTION
This removes a long-lived session with the PKCS11 library and will
open/close for each check-in interval when the daemon is running.

Signed-off-by: Andy Doan <andy@foundries.io>