### PR TITLE
aklite callback: Disable defaults in sota.toml

### DIFF
--- a/contrib/aktualizr-toml-update
+++ b/contrib/aktualizr-toml-update
@@ -5,4 +5,14 @@
 
 [ -z "$CONFIG_FILE" ] && (echo "No CONFIG_FILE specified"; exit 1)
 cp $CONFIG_FILE /etc/sota/conf.d/
+
+# If we take control of tags/apps, then we should try and remove from sota.toml
+if grep -q "^\s*tags\s*=" $CONFIG_FILE 2>/dev/null ; then
+	sed -e '/^\s*tags\s*=/ s/^#*/# MANAGED BY FIOCONFIG: /' -i /var/sota/sota.toml
+fi
+
+if grep -q "^\s*compose_apps\s*=" $CONFIG_FILE 2>/dev/null ; then
+	sed -e '/^\s*compose_apps\s*=/ s/^#*/# MANAGED BY FIOCONFIG: /' -i /var/sota/sota.toml
+fi
+
 systemctl restart aktualizr-lite


### PR DESCRIPTION
Once fioconfig/fioctl take control of aklite configuration values, we
should assume it will own them. aklite now assumes that no entry for
"compose-apps" means run *all* apps. However, if fioconfig removes this
entry from the file it controls, the original versions would potentially
run apps the operator isn't wanting to run.

Signed-off-by: Andy Doan <andy@foundries.io>