### PR TITLE
factory-config-vpn: check for connection state via nmconnection file

### DIFF
--- a/contrib/factory-config-vpn
+++ b/contrib/factory-config-vpn
@@ -4,10 +4,12 @@
 ## files created by fioctl.
 
 vpnid="${VPN_ID-factory-vpn0}"
+nmfile="/etc/NetworkManager/system-connections/${vpnid}.nmconnection"
 
 delete_vpn() {
-	if nmcli connection | grep -q ^$vpnid ; then
-		nmcli connection delete $vpnid
+	if [ -f $nmfile ] ; then
+		rm -f $nmfile
+		nmcli conn reload
 	fi
 }
 
@@ -39,7 +41,6 @@ fi
 
 delete_vpn
 
-nmfile="/etc/NetworkManager/system-connections/${vpnid}.nmconnection"
 cat > $nmfile <<EOF
 [connection]
 id=${vpnid}


### PR DESCRIPTION
Depending on how fast the system performs the server and client
wireguard checks, it might end up getting the wrong result as the NM
connection removal is not done in a synchronous way (it can show up at
the nmcli conn output before fully removed).

Fix the race condition by just using the connection file instead when
checking if the vpn was previously set, as then we don't have to depend
on NM performing the full connection removal process.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>