### PR TITLE
Read default config url from tls.server property in sota.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 bin/*
+build/*
+*.swp

--- a/internal/app.go
+++ b/internal/app.go
@@ -175,7 +175,7 @@ func NewApp(sota_config, secrets_dir string, testing bool) (*App, error) {
 
 	url := os.Getenv("CONFIG_URL")
 	if len(url) == 0 {
-		url = "https://ota-lite.foundries.io:8443/config"
+		url = sota.GetDefault("tls.server", "https://ota-lite.foundries.io:8443").(string) + "/config"
 	}
 
 	app := App{


### PR DESCRIPTION
This change does help in testing and I think even for real customer use cases it would be useful too.