### PR TITLE
aktualizr-toml-update: make sure /etc/sota/conf.d/ exists

### DIFF
--- a/contrib/aktualizr-toml-update
+++ b/contrib/aktualizr-toml-update
@@ -4,6 +4,7 @@
 # It copies the toml file to /etc/sota/conf.d/ and will restart aktualizr-lite
 
 [ -z "$CONFIG_FILE" ] && (echo "No CONFIG_FILE specified"; exit 1)
+mkdir -p -m 0700 /etc/sota/conf.d/
 cp $CONFIG_FILE /etc/sota/conf.d/
 
 # If we take control of tags/apps, then we should try and remove from sota.toml


### PR DESCRIPTION
/etc/sota/conf.d might not exist on the system at the time the handler
gets called, so make sure it gets created first, with the expected
permission (0700).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>