### PR TITLE
Add "safe-handlers" capability

### DIFF
--- a/internal/app_test.go
+++ b/internal/app_test.go
@@ -132,7 +132,7 @@ tls_clientcert_path = "%s/client.pem"
 	if config["foo"].Value == "foo file value" {
 		t.Fatal("Encryption did not occur")
 	}
-	app, err := NewApp(dir, dir, true)
+	app, err := NewApp(dir, dir, true, true)
 	app.configUrl = ts.URL
 	if err != nil {
 		t.Fatal(err)
@@ -207,6 +207,20 @@ func TestExtract(t *testing.T) {
 		_, err := os.Stat(barChanged)
 		if !os.IsNotExist(err) {
 			t.Fatal("OnChanged called when file has not changed")
+		}
+	})
+}
+
+func TestSafeHandler(t *testing.T) {
+	testWrapper(t, nil, func(app *App, client *http.Client, tempdir string) {
+		app.unsafeHandlers = false
+		if err := app.Extract(); err != nil {
+			t.Fatal(err)
+		}
+		barChanged := filepath.Join(tempdir, "bar-changed")
+		_, err := os.Stat(barChanged)
+		if err == nil {
+			t.Fatal("OnChanged called with safe handlers enabled")
 		}
 	})
 }

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 func NewApp(c *cli.Context) (*internal.App, error) {
-	return internal.NewApp(c.String("config"), c.String("secrets-dir"), false)
+	return internal.NewApp(c.String("config"), c.String("secrets-dir"), c.Bool("unsafe-handlers"), false)
 }
 
 func extract(c *cli.Context) error {
@@ -84,6 +84,11 @@ func main() {
 				Value:   "/var/run/secrets",
 				Usage:   "Location to extract configuration to",
 				EnvVars: []string{"SECRETS_DIR"},
+			},
+			&cli.BoolFlag{
+				Name:    "unsafe-handlers",
+				Usage:   "Enable running on-changed handlers defined outside of /usr/share/fioconfig/handlers/",
+				EnvVars: []string{"UNSAFE_CALLBACKS"},
 			},
 		},
 		Commands: []*cli.Command{


### PR DESCRIPTION
This allows a user to fioconfig in a more locked down mode so that
operators can't run arbitrary commands on a device.

Signed-off-by: Andy Doan <andy@foundries.io>