### PR TITLE
Bump golang

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,28 @@
 module github.com/foundriesio/fioconfig
 
-go 1.13
+go 1.17
 
 require (
 	github.com/ThalesIgnite/crypto11 v1.2.1
 	github.com/ethereum/go-ethereum v1.10.15
 	github.com/pelletier/go-toml v1.8.0
+	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli/v2 v2.3.0
+)
+
+require (
+	github.com/btcsuite/btcd v0.20.1-beta // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/miekg/pkcs11 v1.0.3-0.20190429190417-a667d056470f // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/russross/blackfriday/v2 v2.0.1 // indirect
+	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	github.com/thales-e-security/pool v0.0.1 // indirect
+	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 // indirect
+	golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )
 
 replace github.com/ThalesIgnite/crypto11 => github.com/doanac/crypto11 v1.2.2-0.20200715151421-f3d2e17ac497

--- a/internal/app.go
+++ b/internal/app.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -108,7 +107,7 @@ func createClientPkcs11(sota *toml.Tree) (*http.Client, CryptoHandler) {
 		log.Fatal("Unable to load pkcs11 client cert and/or private key")
 	}
 
-	caCert, err := ioutil.ReadFile(caFile)
+	caCert, err := os.ReadFile(caFile)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -139,7 +138,7 @@ func createClientLocal(sota *toml.Tree) (*http.Client, CryptoHandler) {
 		log.Fatal(err)
 	}
 
-	caCert, err := ioutil.ReadFile(caFile)
+	caCert, err := os.ReadFile(caFile)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -198,7 +197,7 @@ func NewApp(sota_config, secrets_dir string, unsafeHandlers, testing bool) (*App
 
 // Do an atomic update of the file if needed
 func updateSecret(secretFile string, newContent []byte) (bool, error) {
-	curContent, err := ioutil.ReadFile(secretFile)
+	curContent, err := os.ReadFile(secretFile)
 	if err == nil && bytes.Equal(newContent, curContent) {
 		return false, nil
 	}

--- a/internal/config.go
+++ b/internal/config.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 )
 
@@ -18,7 +17,7 @@ type ConfigFile struct {
 type ConfigStruct = map[string]*ConfigFile
 
 func UnmarshallFile(c CryptoHandler, encFile string, decrypt bool) (ConfigStruct, error) {
-	content, err := ioutil.ReadFile(encFile)
+	content, err := os.ReadFile(encFile)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to read encrypted file: %w", err)
 	}

--- a/internal/recursive_delete_test.go
+++ b/internal/recursive_delete_test.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,7 +18,7 @@ func TestDeleteEmptyDirs(t *testing.T) {
 
 	sub2 := filepath.Join(root, "sub2")
 	require.Nil(t, os.Mkdir(sub2, 0o750))
-	require.Nil(t, ioutil.WriteFile(filepath.Join(sub2, "foo.txt"), []byte("test"), 0o700))
+	require.Nil(t, os.WriteFile(filepath.Join(sub2, "foo.txt"), []byte("test"), 0o700))
 	require.Nil(t, os.Mkdir(filepath.Join(sub2, "sub2a"), 0o750))
 	require.Nil(t, os.Mkdir(filepath.Join(sub2, "sub2b"), 0o750))
 

--- a/internal/vpn.go
+++ b/internal/vpn.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -50,7 +49,7 @@ func generateKey(privKeyPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if err := ioutil.WriteFile(privKeyPath, pkey, 0600); err != nil {
+	if err := os.WriteFile(privKeyPath, pkey, 0600); err != nil {
 		return "", err
 	}
 	return strings.TrimSpace(string(pub)), nil


### PR DESCRIPTION
The latest LmP is golang 1.17. Let's mark that for development to take advantages of some improvements in the language and prepare for the future deprecation of ioutil