### PR TITLE
Introduce certificate rotation logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,16 +5,17 @@ go 1.17
 require (
 	github.com/ThalesIgnite/crypto11 v1.2.1
 	github.com/ethereum/go-ethereum v1.10.15
+	github.com/miekg/pkcs11 v1.0.3-0.20190429190417-a667d056470f
 	github.com/pelletier/go-toml v1.8.0
 	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli/v2 v2.3.0
+	go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352
 )
 
 require (
 	github.com/btcsuite/btcd v0.20.1-beta // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/miekg/pkcs11 v1.0.3-0.20190429190417-a667d056470f // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -344,6 +344,8 @@ github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352 h1:CCriYyAfq1Br1aIYettdHZTy8mBTIPo7We18TuO/bak=
+go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=

--- a/internal/app.go
+++ b/internal/app.go
@@ -85,7 +85,7 @@ func createClientPkcs11(sota *toml.Tree) (*http.Client, CryptoHandler) {
 
 	cfg := crypto11.Config{
 		Path:        module,
-		TokenLabel:  "aktualizr",
+		TokenLabel:  sota.GetDefault("p11.label", "aktualizr").(string),
 		Pin:         pin,
 		MaxSessions: 2,
 	}

--- a/internal/config.go
+++ b/internal/config.go
@@ -58,6 +58,7 @@ type ConfigFileReq struct {
 type ConfigCreateRequest struct {
 	Reason string          `json:"reason"`
 	Files  []ConfigFileReq `json:"files"`
+	PubKey string          `json:"public-key"`
 }
 
 func updateConfig(app *App, client *http.Client, pubkey string) error {

--- a/internal/ecies.go
+++ b/internal/ecies.go
@@ -3,10 +3,12 @@ package internal
 import (
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/rand"
 	"encoding/base64"
 	"fmt"
 
 	"github.com/ThalesIgnite/crypto11"
+	"github.com/ethereum/go-ethereum/crypto/ecies"
 )
 
 type EciesCrypto struct {
@@ -31,6 +33,15 @@ func (ec *EciesCrypto) Decrypt(value string) ([]byte, error) {
 		return nil, fmt.Errorf("Unable to ECIES decrypt %v", err)
 	}
 	return decrypted, nil
+}
+
+func (ec *EciesCrypto) Encrypt(value string) (string, error) {
+	pub := ecies.ImportECDSAPublic(ec.PrivKey.Public())
+	enc, err := ecies.Encrypt(rand.Reader, pub, []byte(value), nil, nil)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(enc), nil
 }
 
 func (ec *EciesCrypto) Close() {

--- a/internal/rotate.go
+++ b/internal/rotate.go
@@ -1,0 +1,94 @@
+package internal
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+)
+
+type CertRotationState struct {
+	EstServer string
+	StepIdx   int
+}
+
+type CertRotationHandler struct {
+	State     CertRotationState
+	stateFile string
+	app       *App
+	client    *http.Client
+	crypto    *EciesCrypto
+	steps     []CertRotationStep
+}
+
+type CertRotationStep interface {
+	Name() string
+	Execute(handler *CertRotationHandler) error
+}
+
+// NewCertRotationHandler constructs a new handler to initiate a rotation with
+func NewCertRotationHandler(app *App, stateFile, estServer string) *CertRotationHandler {
+	client, crypto := createClient(app.sota)
+	return &CertRotationHandler{
+		State:     CertRotationState{EstServer: estServer},
+		stateFile: stateFile,
+		app:       app,
+		client:    client,
+		crypto:    crypto.(*EciesCrypto),
+		steps:     []CertRotationStep{},
+	}
+}
+
+// RestoreCertRotationHandler will attempt to load a previous rotation attempt's
+// state and return a handler that can process it. This function returns nil when
+// `stateFile` does not exist
+func RestoreCertRotationHandler(app *App, stateFile string) *CertRotationHandler {
+	bytes, err := os.ReadFile(stateFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		} else {
+			// Looks like we started a rotation, we should try and finish it
+			log.Printf("Error reading %s, return empty rotation state: %s", stateFile, err)
+		}
+	}
+	handler := NewCertRotationHandler(app, stateFile, "")
+	if err = json.Unmarshal(bytes, &handler.State); err != nil {
+		log.Printf("Error unmarshalling rotation state, return empty rotation state %s", err)
+		return handler
+	}
+	return handler
+}
+
+func (h *CertRotationHandler) Save() error {
+	bytes, err := json.Marshal(h.State)
+	if err != nil {
+		return err
+	}
+	return safeWrite(h.stateFile, bytes)
+}
+
+func (h *CertRotationHandler) Rotate() error {
+	// Before we even start - we should save our initial state (ie EstServer)
+	// and also make sure we *can* save our state.
+	if err := h.Save(); err != nil {
+		return fmt.Errorf("Unable to save initial state: %w", err)
+	}
+	for idx, step := range h.steps {
+		if idx < h.State.StepIdx {
+			log.Printf("Step already completed: %s", step.Name())
+		} else {
+			log.Printf("Executing step: %s", step.Name())
+			if err := step.Execute(h); err != nil {
+				return err
+			}
+			h.State.StepIdx += 1
+			if saveErr := h.Save(); saveErr != nil {
+				return fmt.Errorf("Unable to save state: %w", saveErr)
+			}
+		}
+	}
+	return os.Rename(h.stateFile, h.stateFile+".completed")
+}

--- a/internal/rotate.go
+++ b/internal/rotate.go
@@ -18,6 +18,9 @@ type CertRotationState struct {
 	// Used by estStep
 	NewKey  string // Path to key or HSM slot id
 	NewCert string // Path to cert or HSM slot id
+
+	// Used by fullCfgStep
+	FullConfigEncrypted string
 }
 
 type CertRotationHandler struct {
@@ -45,6 +48,7 @@ func NewCertRotationHandler(app *App, stateFile, estServer string) *CertRotation
 		crypto:    crypto.(*EciesCrypto),
 		steps: []CertRotationStep{
 			&estStep{},
+			&fullCfgStep{},
 		},
 	}
 }

--- a/internal/rotate.go
+++ b/internal/rotate.go
@@ -24,6 +24,9 @@ type CertRotationState struct {
 
 	// Used by deviceCfgStep
 	DeviceConfigUpdated bool
+
+	// Used by finalizeStep
+	Finalized bool
 }
 
 type CertRotationHandler struct {
@@ -53,6 +56,7 @@ func NewCertRotationHandler(app *App, stateFile, estServer string) *CertRotation
 			&estStep{},
 			&fullCfgStep{},
 			&deviceCfgStep{},
+			&finalizeStep{},
 		},
 	}
 }

--- a/internal/rotate.go
+++ b/internal/rotate.go
@@ -21,6 +21,9 @@ type CertRotationState struct {
 
 	// Used by fullCfgStep
 	FullConfigEncrypted string
+
+	// Used by deviceCfgStep
+	DeviceConfigUpdated bool
 }
 
 type CertRotationHandler struct {
@@ -49,6 +52,7 @@ func NewCertRotationHandler(app *App, stateFile, estServer string) *CertRotation
 		steps: []CertRotationStep{
 			&estStep{},
 			&fullCfgStep{},
+			&deviceCfgStep{},
 		},
 	}
 }

--- a/internal/rotate_config.go
+++ b/internal/rotate_config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"log"
 
 	"github.com/ThalesIgnite/crypto11"
 )
@@ -29,21 +30,106 @@ func (s fullCfgStep) Execute(handler *CertRotationHandler) error {
 	}
 
 	// Encrypt with new key
+	cfgBytes, err := encryptConfig(crypto, config)
+	if err != nil {
+		return err
+	}
+	handler.State.FullConfigEncrypted = string(cfgBytes)
+	return nil
+}
+
+type deviceCfgStep struct{}
+
+func (s deviceCfgStep) Name() string {
+	return "Update device specific configuration on server with new key"
+}
+
+func (s deviceCfgStep) Execute(handler *CertRotationHandler) error {
+	// Load the new crypto handler
+	crypto, err := getCryptoHandler(handler)
+	if err != nil {
+		return err
+	}
+	defer crypto.Close()
+	crypto.PrivKey.Public()
+	pubDer, err := x509.MarshalPKIXPublicKey(crypto.PrivKey.Public())
+	if err != nil {
+		return err
+	}
+	pubPem := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDer})
+
+	// Download/decrypt current device config with current key
+	url := handler.app.configUrl + "-device"
+	res, err := httpGet(handler.client, url, nil)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode == 204 {
+		// Device has no configuration
+		handler.State.DeviceConfigUpdated = true
+		return nil
+	} else if res.StatusCode != 200 {
+		return fmt.Errorf("Unable to get device configuration: HTTP_%d - %s", res.StatusCode, res.String())
+	}
+	config, err := UnmarshallBuffer(handler.crypto, res.Body, true)
+	if err != nil {
+		log.Printf("Unable to decrypt device config with old key, trying new key: %s", err)
+		// There's a chance that we'd uploaded this config with the new key and
+		// had a power failure before we saved the state to disk. Check if
+		// we can decrypt with that key before giving up.
+		if _, err = UnmarshallBuffer(crypto, res.Body, true); err == nil {
+			// We just failed to save the state. We are good.
+			handler.State.DeviceConfigUpdated = true
+			return nil
+		} else {
+			return err
+		}
+	}
+
+	// Encrypt with new key
+	if _, err := encryptConfig(crypto, config); err != nil {
+		return err
+	}
+
+	// Upload to server
+	ccr := ConfigCreateRequest{
+		Reason: "Rotating device client certificate",
+		PubKey: string(pubPem),
+	}
+	for name, entry := range config {
+		ccr.Files = append(ccr.Files, ConfigFileReq{
+			Name:        name,
+			Value:       entry.Value,
+			Unencrypted: entry.Unencrypted,
+			OnChanged:   entry.OnChanged,
+		})
+	}
+	res, err = httpPatch(handler.client, handler.app.configUrl, ccr)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode < 200 || res.StatusCode > 204 {
+		return fmt.Errorf("Unable to patch device config: HTTP_%d - %s", res.StatusCode, res.String())
+	}
+	handler.State.DeviceConfigUpdated = true
+	return nil
+}
+
+func encryptConfig(crypto *EciesCrypto, config map[string]*ConfigFile) ([]byte, error) {
 	for _, cfgFile := range config {
 		if !cfgFile.Unencrypted {
 			val, err := crypto.Encrypt(cfgFile.Value)
 			if err != nil {
-				return fmt.Errorf("Unable to re-encrypt config: %w", err)
+				return nil, fmt.Errorf("Unable to re-encrypt config: %w", err)
 			}
 			cfgFile.Value = val
 		}
 	}
 	val, err := json.Marshal(config)
 	if err != nil {
-		return fmt.Errorf("Unexpected error marshalling config: %w", err)
+		return nil, fmt.Errorf("Unexpected error marshalling config: %w", err)
 	}
-	handler.State.FullConfigEncrypted = string(val)
-	return nil
+	return val, nil
 }
 
 func getCryptoHandler(h *CertRotationHandler) (*EciesCrypto, error) {

--- a/internal/rotate_config.go
+++ b/internal/rotate_config.go
@@ -1,0 +1,79 @@
+package internal
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+
+	"github.com/ThalesIgnite/crypto11"
+)
+
+type fullCfgStep struct{}
+
+func (s fullCfgStep) Name() string {
+	return "Update local configuration with new key"
+}
+
+func (s fullCfgStep) Execute(handler *CertRotationHandler) error {
+	crypto, err := getCryptoHandler(handler)
+	if err != nil {
+		return err
+	}
+	defer crypto.Close()
+
+	// Open/decrypt full config with current key
+	config, err := UnmarshallFile(handler.crypto, handler.app.EncryptedConfig, true)
+	if err != nil {
+		return fmt.Errorf("Unable open current encrypted config: %w", err)
+	}
+
+	// Encrypt with new key
+	for _, cfgFile := range config {
+		if !cfgFile.Unencrypted {
+			val, err := crypto.Encrypt(cfgFile.Value)
+			if err != nil {
+				return fmt.Errorf("Unable to re-encrypt config: %w", err)
+			}
+			cfgFile.Value = val
+		}
+	}
+	val, err := json.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("Unexpected error marshalling config: %w", err)
+	}
+	handler.State.FullConfigEncrypted = string(val)
+	return nil
+}
+
+func getCryptoHandler(h *CertRotationHandler) (*EciesCrypto, error) {
+	if !h.usePkcs11() {
+		block, _ := pem.Decode([]byte(h.State.NewKey))
+		key, err := x509.ParseECPrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to parse new private key: %w", err)
+		}
+		return NewEciesLocalHandler(key).(*EciesCrypto), nil
+	}
+
+	module := tomlGet(h.app.sota, "p11.module")
+	pin := tomlGet(h.app.sota, "p11.pass")
+
+	cfg := crypto11.Config{
+		Path:        module,
+		TokenLabel:  h.app.sota.GetDefault("p11.label", "aktualizr").(string),
+		Pin:         pin,
+		MaxSessions: 2,
+	}
+
+	ctx, err := crypto11.Configure(&cfg)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to configure crypto11 library: %w", err)
+	}
+
+	privKey, err := ctx.FindKeyPair(idToBytes(h.State.NewKey), nil)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to find new HSM private key: %w", err)
+	}
+	return NewEciesPkcs11Handler(ctx, privKey).(*EciesCrypto), nil
+}

--- a/internal/rotate_est.go
+++ b/internal/rotate_est.go
@@ -1,0 +1,207 @@
+package internal
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+
+	"github.com/ThalesIgnite/crypto11"
+	"github.com/miekg/pkcs11"
+	"go.mozilla.org/pkcs7"
+)
+
+var (
+	oidKeyUsage         = asn1.ObjectIdentifier([]int{2, 5, 29, 15})
+	oidExtendedKeyUsage = asn1.ObjectIdentifier([]int{2, 5, 29, 37})
+
+	asn1DigitalSignature = []byte{3, 2, 7, 128}
+	asn1TlsWebClientAuth = []byte{48, 10, 6, 8, 43, 6, 1, 5, 5, 7, 3, 2}
+)
+
+type estStep struct{}
+
+func (s estStep) Name() string {
+	return "Generate new certificate"
+}
+
+func (s estStep) Execute(handler *CertRotationHandler) error {
+	// Find the current certificate so we can build the proper EST request
+	tlsCert := handler.client.Transport.(*http.Transport).TLSClientConfig.Certificates[0]
+	cert, err := x509.ParseCertificate(tlsCert.Certificate[0])
+	if err != nil {
+		return nil
+	}
+
+	var signer crypto.Signer
+	var newKey string
+
+	// Generate a new private key
+	if handler.usePkcs11() {
+		newKey = s.nextPkeyId(handler)
+		pubAttr, err := crypto11.NewAttributeSetWithIDAndLabel(idToBytes(newKey), []byte("tls"))
+		if err != nil {
+			return fmt.Errorf("Unable to define pkcs11 attributes for new key: %w", err)
+		}
+		// The default ecdsa logic in crypto11 does not include the ability to
+		// derive which is required for ECIES decryption
+		pubAttr.AddIfNotPresent([]*pkcs11.Attribute{pkcs11.NewAttribute(pkcs11.CKA_DERIVE, true)})
+		privAttr := pubAttr.Copy()
+		signer, err = handler.crypto.ctx.GenerateECDSAKeyPairWithAttributes(pubAttr, privAttr, elliptic.P256())
+		if err != nil {
+			return fmt.Errorf("Unable to generate new keypair in HSM: %w", err)
+		}
+	} else {
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			return fmt.Errorf("Unable to generate new private key: %w", err)
+		}
+		keyBytes, err := x509.MarshalECPrivateKey(key)
+		if err != nil {
+			return fmt.Errorf("Unable to serialize new private key: %w", err)
+		}
+		keyBytes = pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes})
+		newKey = string(keyBytes)
+		signer = key
+	}
+
+	// Ask EST server for new cert
+	csrBytes, err := createB64CsrDer(signer, cert)
+	if err != nil {
+		return err
+	}
+
+	url := handler.State.EstServer + "/simplereenroll"
+	res, err := handler.client.Post(url, "application/pkcs10", bytes.NewBuffer(csrBytes))
+	if err != nil {
+		return fmt.Errorf("Unable to submit certificate signing request: %w", err)
+	}
+	buf, err := io.ReadAll(res.Body)
+	if err != nil {
+		return fmt.Errorf("Unable to read certificate response body: HTTP_%d - %w", res.StatusCode, err)
+	}
+	if res.StatusCode != 201 {
+		return fmt.Errorf("Unable to obtain new certificate: HTTP_%d - %s", res.StatusCode, string(buf))
+	}
+	ct := res.Header.Get("content-type")
+	if ct != "application/pkcs7-mime" {
+		return fmt.Errorf("Unexpected content-type return in certificate response: %s", ct)
+	}
+	estCert, err := decodeEstResponse(string(buf))
+	if err != nil {
+		return err
+	}
+
+	// Do minimal sanity checking on the new cert
+	if err = verifyNewCert(cert, estCert); err != nil {
+		return err
+	}
+
+	// Update our state
+	if handler.usePkcs11() {
+		newCert := s.nextCertId(handler)
+		if err = handler.crypto.ctx.ImportCertificateWithLabel(idToBytes(newCert), []byte("client"), estCert); err != nil {
+			return fmt.Errorf("Unable to import new cert into HSM: %w", err)
+		}
+		handler.State.NewCert = newCert
+	} else {
+		handler.State.NewCert = string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: estCert.Raw}))
+	}
+
+	handler.State.NewKey = newKey
+	return nil
+}
+
+func (s estStep) nextPkeyId(handler *CertRotationHandler) string {
+	cur := tomlGet(handler.app.sota, "p11.tls_pkey_id")
+	for _, val := range handler.State.PkeySlotIds {
+		if val != cur {
+			return val
+		}
+	}
+	log.Printf("ERROR: Unable to find a new key id. Will use slot 07")
+	return "07"
+}
+
+func (s estStep) nextCertId(handler *CertRotationHandler) string {
+	cur := tomlGet(handler.app.sota, "p11.tls_clientcert_id")
+	for _, val := range handler.State.CertSlotIds {
+		if val != cur {
+			return val
+		}
+	}
+	log.Printf("ERROR: Unable to find a new clientcert id. Will use slot 09")
+	return "09"
+}
+
+// createB64CsrDer creates the payload for an EST simplereenroll payload. The
+// main thing the EST server will want is for the x509 subject to be the same.
+// Then we also need to ask for the proper x509 extensions.
+func createB64CsrDer(key crypto.Signer, cert *x509.Certificate) ([]byte, error) {
+	template := x509.CertificateRequest{
+		PublicKeyAlgorithm: 0,
+		PublicKey:          key.Public(),
+		RawSubject:         cert.RawSubject,
+		ExtraExtensions: []pkix.Extension{
+			{
+				Id:       oidKeyUsage,
+				Critical: true,
+				Value:    asn1DigitalSignature,
+			},
+			{
+				Id:       oidExtendedKeyUsage,
+				Critical: true,
+				Value:    asn1TlsWebClientAuth,
+			},
+		},
+	}
+
+	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &template, key)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(base64.StdEncoding.EncodeToString(csrBytes)), nil
+}
+
+func decodeEstResponse(estResponse string) (*x509.Certificate, error) {
+	bytes, err := base64.StdEncoding.DecodeString(estResponse)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to base64 decode EST response: %w", err)
+	}
+	p7, err := pkcs7.Parse(bytes)
+	if err != nil {
+		return nil, fmt.Errorf("Invalid pkcs7 data in EST response: %w", err)
+	}
+	return p7.Certificates[0], nil
+}
+
+func verifyNewCert(curCert, newCert *x509.Certificate) error {
+	if !bytes.Equal(curCert.RawSubject, newCert.RawSubject) {
+		return errors.New("New cert's subject does not match current cert's")
+	}
+	foundDigitalSig := false
+	foundClientAuth := false
+	for _, ext := range newCert.Extensions {
+		if !foundDigitalSig && ext.Id.Equal(oidKeyUsage) {
+			foundDigitalSig = bytes.Equal(ext.Value, asn1DigitalSignature)
+		} else if !foundClientAuth && ext.Id.Equal(oidExtendedKeyUsage) {
+			foundClientAuth = bytes.Equal(ext.Value, asn1TlsWebClientAuth)
+		}
+	}
+
+	if foundDigitalSig && foundClientAuth {
+		return nil
+	}
+	return errors.New("Missing required extensions for Digital Signature and/or TLS Web Client Authentication")
+}

--- a/internal/rotate_finalize.go
+++ b/internal/rotate_finalize.go
@@ -49,7 +49,12 @@ func (s finalizeStep) Execute(handler *CertRotationHandler) error {
 	if err = safeWrite(path, bytes); err != nil {
 		return fmt.Errorf("Unable to update sota.toml with new cert locations: %w", err)
 	}
-	path = filepath.Join(storagePath, "config.encrypted")
+	return s.finalizeConfigEncrypted(handler)
+}
+
+func (s finalizeStep) finalizeConfigEncrypted(handler *CertRotationHandler) error {
+	storagePath := tomlGet(handler.app.sota, "storage.path")
+	path := filepath.Join(storagePath, "config.encrypted")
 	if err := safeWrite(path, []byte(handler.State.FullConfigEncrypted)); err != nil {
 		return fmt.Errorf("Error updating config.encrypted: %w", err)
 	}

--- a/internal/rotate_finalize.go
+++ b/internal/rotate_finalize.go
@@ -1,0 +1,58 @@
+package internal
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type finalizeStep struct{}
+
+func (s finalizeStep) Name() string {
+	return "Finalize aktualizr configuration"
+}
+
+func (s finalizeStep) Execute(handler *CertRotationHandler) error {
+	storagePath := tomlGet(handler.app.sota, "storage.path")
+	if handler.usePkcs11() {
+		// Point at the new key ids
+		handler.app.sota.Set("p11.tls_pkey_id", handler.State.NewKey)
+		handler.app.sota.Set("p11.tls_clientcert_id", handler.State.NewCert)
+	} else {
+		// Write out two new files and update sota.toml
+		// They need to be *new* unique names, so just use tempfile since it
+		// includes the logic for uniqueness
+		files := [][3]string{
+			{"pkey.*.pem", "import.tls_pkey_path", handler.State.NewKey},
+			{"client.*.pem", "import.tls_clientcert_path", handler.State.NewCert},
+		}
+		for _, pair := range files {
+			f, err := os.CreateTemp(storagePath, pair[0])
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			if _, err = f.WriteString(pair[2]); err != nil {
+				return err
+			}
+			if err = f.Sync(); err != nil {
+				return err
+			}
+			handler.app.sota.Set(pair[1], f.Name())
+		}
+	}
+	bytes, err := handler.app.sota.Marshal()
+	if err != nil {
+		return fmt.Errorf("Unable to marshall new sota.toml")
+	}
+	path := filepath.Join(storagePath, "sota.toml")
+	if err = safeWrite(path, bytes); err != nil {
+		return fmt.Errorf("Unable to update sota.toml with new cert locations: %w", err)
+	}
+	path = filepath.Join(storagePath, "config.encrypted")
+	if err := safeWrite(path, []byte(handler.State.FullConfigEncrypted)); err != nil {
+		return fmt.Errorf("Error updating config.encrypted: %w", err)
+	}
+	handler.State.Finalized = true
+	return nil
+}

--- a/internal/rotate_test.go
+++ b/internal/rotate_test.go
@@ -1,0 +1,60 @@
+package internal
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testStep struct {
+	name      string
+	execError error
+}
+
+func (t testStep) Name() string {
+	return t.name
+}
+
+func (t testStep) Execute(handler *CertRotationHandler) error {
+	return t.execError
+}
+
+func TestRotationHandler(t *testing.T) {
+	testWrapper(t, nil, func(app *App, client *http.Client, tmpdir string) {
+		stateFile := filepath.Join(tmpdir, "rotate.state")
+		handler := NewCertRotationHandler(app, stateFile, "est-server-doesn't-matter")
+
+		handler.steps = []CertRotationStep{
+			&testStep{"step1", nil},
+		}
+
+		require.Nil(t, handler.Rotate())
+
+		_, err := os.Stat(stateFile + ".completed")
+		require.Nil(t, err)
+
+		// Do one that fails, it should leave a statefile so we know where
+		// we got to
+		handler.State.StepIdx = 0
+		handler.steps = []CertRotationStep{
+			&testStep{"step1", errors.New("1")},
+		}
+		require.NotNil(t, handler.Rotate())
+		handler = RestoreCertRotationHandler(app, stateFile)
+		require.NotNil(t, handler)
+		require.Equal(t, "est-server-doesn't-matter", handler.State.EstServer)
+
+		// Check that we can resume from a non-zero StepIdx
+		handler.steps = []CertRotationStep{
+			&testStep{"step1", errors.New("Step 0 shouldn't have been run")},
+			&testStep{"step2", nil},
+		}
+		handler.State.StepIdx = 1
+		require.Nil(t, handler.Rotate())
+		require.Equal(t, 2, handler.State.StepIdx)
+	})
+}

--- a/internal/rotate_test.go
+++ b/internal/rotate_test.go
@@ -1,13 +1,17 @@
 package internal
 
 import (
+	"crypto/tls"
+	"encoding/base64"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.mozilla.org/pkcs7"
 )
 
 type testStep struct {
@@ -21,6 +25,44 @@ func (t testStep) Name() string {
 
 func (t testStep) Execute(handler *CertRotationHandler) error {
 	return t.execError
+}
+
+type testClient struct {
+	srv    *httptest.Server
+	client *http.Client
+}
+
+func WithEstServer(t *testing.T, testFunc func(tc testClient)) {
+	kp, err := tls.X509KeyPair([]byte(client_pem), []byte(pkey_pem))
+	require.Nil(t, err)
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// A dumb server that just returns the same cert back to the requestor
+		w.Header().Add("content-type", "application/pkcs7-mime")
+		w.WriteHeader(201)
+		bytes, err := pkcs7.DegenerateCertificate(kp.Certificate[0])
+		require.Nil(t, err)
+		bytes = []byte(base64.StdEncoding.EncodeToString(bytes))
+		_, err = w.Write(bytes)
+		require.Nil(t, err)
+	}))
+
+	srv.TLS = &tls.Config{
+		ClientAuth: tls.RequestClientCert,
+	}
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+
+	client := srv.Client()
+	transport := client.Transport.(*http.Transport)
+	transport.TLSClientConfig.Certificates = []tls.Certificate{kp}
+
+	tc := testClient{
+		srv:    srv,
+		client: client,
+	}
+
+	testFunc(tc)
 }
 
 func TestRotationHandler(t *testing.T) {
@@ -56,5 +98,20 @@ func TestRotationHandler(t *testing.T) {
 		handler.State.StepIdx = 1
 		require.Nil(t, handler.Rotate())
 		require.Equal(t, 2, handler.State.StepIdx)
+	})
+}
+
+func TestEst(t *testing.T) {
+	WithEstServer(t, func(tc testClient) {
+		testWrapper(t, nil, func(app *App, client *http.Client, tmpdir string) {
+			stateFile := filepath.Join(tmpdir, "rotate.state")
+			handler := NewCertRotationHandler(app, stateFile, tc.srv.URL+"/.well-known/est")
+
+			step := estStep{}
+
+			require.Nil(t, step.Execute(handler))
+			require.True(t, len(handler.State.NewCert) > 0)
+			require.True(t, len(handler.State.NewKey) > 0)
+		})
 	})
 }


### PR DESCRIPTION
This is part one of a series of patches being introduced to support rotation of client certificates.

This first part does sets up all the pieces to perform a rotation. It's robust enough to be re-run after a failure and finish the operation.

It's missing a few things that I'll introduce in follow-up PRs including:
 * emitting events to the device-gateway to track the progress of the rotation
 * an on-change handler so that config changes can trigger this
 * More robust retry logic for HTTP communications with the device-gateway

With this PR and my patched device-gateway, I'm able to rotate certificates in production.