### PR TITLE
rotation: Add on-change handler for fioctl

### DIFF
--- a/contrib/renew-client-cert
+++ b/contrib/renew-client-cert
@@ -1,0 +1,61 @@
+#!/bin/sh -e
+
+# This is an OnChanged handler that can handle requests to renew the client
+# certificates used by the device to connect to the device gateway
+
+[ -z "$CONFIG_FILE" ] && (echo "No CONFIG_FILE specified"; exit 1)
+[ -f "$CONFIG_FILE" ] || (echo "$CONFIG_FILE does not exist"; exit 1)
+[ -z "$SOTA_DIR" ] && (echo "No SOTA_DIR specified"; exit 1)
+[ -d "$SOTA_DIR" ] || (echo "$SOTA_DIR does not exist"; exit 1)
+
+fioconfig=$(which fioconfig)
+
+rotation_id=$(cat $CONFIG_FILE | grep ROTATIONID | cut -d= -f2)
+[ -z "$rotation_id" ] && (echo "No ROTATIONID found in config file"; exit 1)
+echo "Rotation ID for rotation is $rotation_id"
+
+est_server=$(cat $CONFIG_FILE | grep ESTSERVER | cut -d= -f2)
+[ -z "$est_server" ] && (echo "No ESTSERVER found in config file"; exit 1)
+echo "EST server for rotation is $est_server"
+
+# We need to toggle between two different pkcs11 slot ids to rotate on HSMs:
+pkey_ids=$(cat $CONFIG_FILE | grep PKEYIDS | cut -d= -f2)
+if [ -n "$pkey_ids" ]; then
+	echo "PKCS11 key IDs: ${pkey_ids}"
+fi
+cert_ids=$(cat $CONFIG_FILE | grep CERTIDS | cut -d= -f2)
+if [ -n "$cert_ids" ]; then
+	echo "PKCS11 cert IDs: ${cert_ids}"
+fi
+
+rotate() {
+	extra_args=""
+	if [ -n "$pkey_ids" ]; then
+		extra_args="--pkcs11-key-ids=$pkey_ids"
+	fi
+	if [ -n "$cert_ids" ]; then
+		extra_args="$extra_args --pkcs11-cert-ids=$cert_ids"
+	fi
+	exec $fioconfig -c $SOTA_DIR renew-cert $extra_args $est_server $rotation_id 
+}
+
+# We'll execute under two conditions:
+# 1) A cert rotation has never taken place (cert-rotation.state.completed does not exist)
+# 2) We need to do a new rotation ($rotation_id != cert-rotation.state.completed's RotationId)
+
+active_file="${SOTA_DIR}/cert-rotation.state"
+completed_file="${active_file}.completed"
+
+if [ ! -f "$completed_file" ] ; then
+	echo "Rotating certs: cert-rotation.state.completed does not exist"
+	rotate
+fi
+
+idmatch=$(grep -Po '"RotationId":.*?[^\\]",' $completed_file)
+completed_id=$(echo $idmatch | cut -d\"  -f4)
+if [ "$completed_id" !=  "$rotation_id" ] ; then
+	echo "Rotating certs: Rotation ID has changed from $completed_id -> $rotation_id"
+	rotate
+fi
+
+echo "Rotation not needed. Current rotation ID is $rotation_id"

--- a/internal/app.go
+++ b/internal/app.go
@@ -290,6 +290,7 @@ func (a *App) runOnChanged(fname string, fullpath string, onChanged []string) {
 			log.Printf("Running on-change command for %s: %v", fname, onChanged)
 			cmd := exec.Command(onChanged[0], onChanged[1:]...)
 			cmd.Env = append(os.Environ(), "CONFIG_FILE="+fullpath)
+			cmd.Env = append(cmd.Env, "SOTA_DIR="+tomlGet(a.sota, "storage.path"))
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
 			if err := cmd.Run(); err != nil {

--- a/internal/app_test.go
+++ b/internal/app_test.go
@@ -108,7 +108,10 @@ cert_source = "file"
 tls_cacert_path = "%s/root.crt"
 tls_pkey_path = "%s/pkey.pem"
 tls_clientcert_path = "%s/client.pem"
-	`, ts.URL, dir, dir, dir)
+
+[storage]
+path = "%s"
+	`, ts.URL, dir, dir, dir, dir)
 	if err := os.WriteFile(filepath.Join(dir, "sota.toml"), []byte(sota), 0644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/rotate.go
+++ b/internal/rotate.go
@@ -11,6 +11,7 @@ import (
 
 type CertRotationState struct {
 	EstServer   string
+	RotationId  string // A unique ID to identify this rotation operation with
 	StepIdx     int
 	PkeySlotIds []string // Available IDs we can use when generating a new key
 	CertSlotIds []string // Available IDs we can use when saving the new cert

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func renewCert(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	if c.NArg() != 1 {
+	if c.NArg() != 1 && c.NArg() != 2 {
 		cli.ShowCommandHelpAndExit(c, "renew-cert", 1)
 	}
 	server := c.Args().Get(0)
@@ -96,6 +96,10 @@ func renewCert(c *cli.Context) error {
 	handler.State.PkeySlotIds = strings.Split(idsStr, ",")
 	idsStr = c.String("pkcs11-cert-ids")
 	handler.State.CertSlotIds = strings.Split(idsStr, ",")
+
+	if c.NArg() == 2 {
+		handler.State.RotationId = c.Args().Get(1)
+	}
 
 	log.Printf("Performing certificate renewal")
 	if err = handler.Rotate(); err == nil {
@@ -162,7 +166,7 @@ func main() {
 			},
 			{
 				Name:     "renew-cert",
-				HelpName: "renew-cert <EST Server>",
+				HelpName: "renew-cert <EST Server> [<rotation-id>]",
 				Usage:    "Renew device's TLS keypair used with device-gateway",
 				Action: func(c *cli.Context) error {
 					return renewCert(c)


### PR DESCRIPTION
This creates a flexible way for a certificate renew to be triggered via a configuration change. It can be tested with a conf file that looks like:
```
 ESTSERVER=https://4a53f331-6f01-4694-8a97-af253d4d9b63.est.foundries.io:8443/.well-known/est
 TIMESTAMP=1667240722
 PKEYIDS=01,07
 CERTIDS=03,09
```
Signed-off-by: Andy Doan <andy@foundries.io>