### PR TITLE
rotation: Fix bad resume logic

### DIFF
--- a/internal/rotate.go
+++ b/internal/rotate.go
@@ -126,7 +126,7 @@ func (h *CertRotationHandler) ResumeRotation(online bool) error {
 		if h.State.DeviceConfigUpdated && !h.State.Finalized {
 			log.Print("Incomplete certificate rotation state found. Will attempt to complete")
 			step := finalizeStep{}
-			if err := step.finalizeConfigEncrypted(h); err != nil {
+			if err := step.Execute(h); err != nil {
 				return err
 			}
 			// By calling save and not renaming the file .completed, `.Rotate`

--- a/internal/rotate_finalize.go
+++ b/internal/rotate_finalize.go
@@ -49,12 +49,8 @@ func (s finalizeStep) Execute(handler *CertRotationHandler) error {
 	if err = safeWrite(path, bytes); err != nil {
 		return fmt.Errorf("Unable to update sota.toml with new cert locations: %w", err)
 	}
-	return s.finalizeConfigEncrypted(handler)
-}
 
-func (s finalizeStep) finalizeConfigEncrypted(handler *CertRotationHandler) error {
-	storagePath := tomlGet(handler.app.sota, "storage.path")
-	path := filepath.Join(storagePath, "config.encrypted")
+	path = filepath.Join(storagePath, "config.encrypted")
 	if err := safeWrite(path, []byte(handler.State.FullConfigEncrypted)); err != nil {
 		return fmt.Errorf("Error updating config.encrypted: %w", err)
 	}


### PR DESCRIPTION
The resume logic was assuming when the given state existed that sota.toml would be updated. There's no guarantee for that. The full step is cheap to run and can be re-run w/o causing damage, so we should just simply re-run the step.

Signed-off-by: Andy Doan <andy@foundries.io>