### PR TITLE
rotation: Use device-gateway API to set next key

### DIFF
--- a/internal/rotate.go
+++ b/internal/rotate.go
@@ -55,6 +55,7 @@ func NewCertRotationHandler(app *App, stateFile, estServer string) *CertRotation
 		crypto:    crypto.(*EciesCrypto),
 		steps: []CertRotationStep{
 			&estStep{},
+			&lockStep{},
 			&fullCfgStep{},
 			&deviceCfgStep{},
 			&finalizeStep{},

--- a/internal/rotate_lock.go
+++ b/internal/rotate_lock.go
@@ -1,0 +1,41 @@
+package internal
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+)
+
+type lockStep struct{}
+
+type DeviceUpdate struct {
+	NextPubKey string `json:"next_pubkey"`
+}
+
+func (s lockStep) Name() string {
+	return "Lock device configuration on server"
+}
+
+func (s lockStep) Execute(handler *CertRotationHandler) error {
+	crypto, err := getCryptoHandler(handler)
+	if err != nil {
+		return err
+	}
+	pub := crypto.PrivKey.Public()
+	crypto.Close()
+
+	pubBytes, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return err
+	}
+
+	pubBytes = pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubBytes})
+
+	url := tomlGet(handler.app.sota, "tls.server") + "/device"
+	if res, err := httpPatch(handler.client, url, DeviceUpdate{string(pubBytes)}); err != nil {
+		return err
+	} else if res.StatusCode != 200 {
+		return fmt.Errorf("Unable to set device's next public key: HTTP_%d - %s", res.StatusCode, res.String())
+	}
+	return nil
+}


### PR DESCRIPTION
Rather than the device-gateway's normal trust-on-first-use, we should have the device present it's new client certificate to the backend. This is good for 2 reasons:

 * Eliminate a threat-vector where a malicious user with access to PKI could denial-of-service device fleet by creating new certs with existing device UUIDs' and then doing an operation against the device-gateway.

 * Knowing there's a new key allows us to reject `fioctl device config` attempts until it initiates contact with this new key.

Signed-off-by: Andy Doan <andy@foundries.io>