### PR TITLE
rotation: Emit update events to device gateway

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/ThalesIgnite/crypto11 v1.2.5
 	github.com/ethereum/go-ethereum v1.10.15
+	github.com/google/uuid v1.1.5
 	github.com/miekg/pkcs11 v1.0.3-0.20190429190417-a667d056470f
 	github.com/pelletier/go-toml v1.8.0
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,7 @@ github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OI
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.1.5 h1:kxhtnfFVi+rYdOALN0B3k9UT86zVJKfBimRaciULW4I=
 github.com/google/uuid v1.1.5/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=

--- a/internal/current_target.go
+++ b/internal/current_target.go
@@ -1,0 +1,35 @@
+package internal
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/pelletier/go-toml"
+)
+
+type CurrentTarget struct {
+	Name    string
+	Version int
+}
+
+func LoadCurrentTarget(currentTargeFile string) (CurrentTarget, error) {
+	var cur CurrentTarget
+	ctToml, err := toml.LoadFile(currentTargeFile)
+	if err != nil {
+		return cur, err
+	}
+	if val, ok := ctToml.Get("TARGET_NAME").(string); !ok || len(val) == 0 {
+		return cur, errors.New("Unable to parse current-target. No TARGET_NAME specified")
+	} else {
+		cur.Name = val
+	}
+	if val, ok := ctToml.Get("CUSTOM_VERSION").(string); !ok || len(val) == 0 {
+		return cur, errors.New("Unable to parse current-target. No CUSTOM_VERSON specified")
+	} else {
+		cur.Version, err = strconv.Atoi(val)
+		if err != nil {
+			return cur, err
+		}
+	}
+	return cur, nil
+}

--- a/internal/current_target_test.go
+++ b/internal/current_target_test.go
@@ -1,0 +1,71 @@
+package internal
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadCurrentTarget(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test-current-target")
+	content := `
+TARGET_NAME="intel-corei7-64-lmp-277"
+CUSTOM_VERSION="277"
+LMP_MANIFEST_SHA="afc74c3ecb0528238b08a40d8b576792cc11c202"
+META_SUBSCRIBER_OVERRIDES_SHA="c1dfca8299829e9d1bf5d10174cf9fbcc788a9a8"
+CONTAINERS_SHA="821478af94b8199114d5c8731bd53f17a5663ff8"
+TAG="production"
+	`
+	require.Nil(t, os.WriteFile(path, []byte(content), 0o700))
+	tgt, err := LoadCurrentTarget(path)
+	require.Nil(t, err)
+	require.Equal(t, "intel-corei7-64-lmp-277", tgt.Name)
+	require.Equal(t, 277, tgt.Version)
+}
+
+func TestLoadCurrentTargetBadContent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test-current-target")
+	content := `
+LINE_MISSING_EQUALS_CHAR
+CUSTOM_VERSION="277"
+LMP_MANIFEST_SHA="afc74c3ecb0528238b08a40d8b576792cc11c202"
+META_SUBSCRIBER_OVERRIDES_SHA="c1dfca8299829e9d1bf5d10174cf9fbcc788a9a8"
+CONTAINERS_SHA="821478af94b8199114d5c8731bd53f17a5663ff8"
+TAG="production"
+	`
+	require.Nil(t, os.WriteFile(path, []byte(content), 0o700))
+	_, err := LoadCurrentTarget(path)
+	require.NotNil(t, err)
+}
+
+func TestLoadCurrentMissingRequired(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test-current-target")
+	content := `
+#TARGET_NAME="intel-corei7-64-lmp-277"
+CUSTOM_VERSION="277"
+LMP_MANIFEST_SHA="afc74c3ecb0528238b08a40d8b576792cc11c202"
+META_SUBSCRIBER_OVERRIDES_SHA="c1dfca8299829e9d1bf5d10174cf9fbcc788a9a8"
+CONTAINERS_SHA="821478af94b8199114d5c8731bd53f17a5663ff8"
+TAG="production"
+	`
+	require.Nil(t, os.WriteFile(path, []byte(content), 0o700))
+	_, err := LoadCurrentTarget(path)
+	require.NotNil(t, err)
+}
+
+func TestLoadCurrentBadVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test-current-target")
+	content := `
+#TARGET_NAME="intel-corei7-64-lmp-277"
+CUSTOM_VERSION="NotANumber"
+LMP_MANIFEST_SHA="afc74c3ecb0528238b08a40d8b576792cc11c202"
+META_SUBSCRIBER_OVERRIDES_SHA="c1dfca8299829e9d1bf5d10174cf9fbcc788a9a8"
+CONTAINERS_SHA="821478af94b8199114d5c8731bd53f17a5663ff8"
+TAG="production"
+	`
+	require.Nil(t, os.WriteFile(path, []byte(content), 0o700))
+	_, err := LoadCurrentTarget(path)
+	require.NotNil(t, err)
+}

--- a/internal/rotate_events.go
+++ b/internal/rotate_events.go
@@ -1,0 +1,94 @@
+package internal
+
+import (
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// EventSync in an interface for sending events to device-gateway. The abstraction
+// makes it easier to write unit tests
+type EventSync interface {
+	NotifyStarted()
+	NotifyStep(name string, err error)
+	NotifyCompleted(err error)
+	SetCorrelationId(corId string)
+}
+
+type NoOpEventSync struct{}
+
+func (s NoOpEventSync) NotifyStarted()                    {}
+func (s NoOpEventSync) NotifyCompleted(err error)         {}
+func (s NoOpEventSync) NotifyStep(name string, err error) {}
+func (s NoOpEventSync) SetCorrelationId(corId string)     {}
+
+type DgEventSync struct {
+	client        *http.Client
+	url           string
+	correlationId string
+	target        CurrentTarget
+}
+
+func (s *DgEventSync) SetCorrelationId(corId string) {
+	s.correlationId = corId
+}
+func (s *DgEventSync) NotifyStarted() {
+	s.notify("CertRotationStarted", nil)
+}
+func (s *DgEventSync) NotifyCompleted(err error) {
+	s.notify("CertRotationCompleted", err)
+}
+func (s *DgEventSync) NotifyStep(name string, err error) {
+	s.notify(name, err)
+}
+func (s *DgEventSync) notify(event string, err error) {
+	details := ""
+	if err != nil {
+		details = err.Error()
+	}
+	evt := []DgUpdateEvent{
+		{
+			Id:         uuid.New().String(),
+			DeviceTime: time.Now().Format(time.RFC3339),
+			Event: DgEvent{
+				CorrelationId: s.correlationId,
+				Success:       err == nil,
+				TargetName:    s.target.Name,
+				Version:       strconv.Itoa(s.target.Version),
+				Details:       details,
+			},
+			EventType: DgEventType{
+				Id:      event,
+				Version: 0,
+			},
+		},
+	}
+	res, err := httpPost(s.client, s.url, evt)
+	if err != nil {
+		log.Printf("Unable to send event: %s", err)
+	} else if res.StatusCode < 200 || res.StatusCode > 204 {
+		log.Printf("Server could not process event(%s): HTTP_%d - %s", event, res.StatusCode, res.String())
+	}
+}
+
+type DgEvent struct {
+	CorrelationId string `json:"correlationId"`
+	//Ecu           string `json:"ecu"`
+	Success    bool   `json:"success"`
+	TargetName string `json:"targetName"`
+	Version    string `json:"version"`
+	Details    string `json:"details,omitempty"`
+}
+type DgEventType struct {
+	Id      string `json:"id"`
+	Version int    `json:"version"`
+}
+type DgUpdateEvent struct {
+	Id         string      `json:"id"`
+	DeviceTime string      `json:"deviceTime"`
+	Event      DgEvent     `json:"event"`
+	EventType  DgEventType `json:"eventType"`
+}

--- a/internal/rotate_test.go
+++ b/internal/rotate_test.go
@@ -77,6 +77,7 @@ func TestRotationHandler(t *testing.T) {
 	testWrapper(t, nil, func(app *App, client *http.Client, tmpdir string) {
 		stateFile := filepath.Join(tmpdir, "rotate.state")
 		handler := NewCertRotationHandler(app, stateFile, "est-server-doesn't-matter")
+		handler.eventSync = NoOpEventSync{}
 
 		handler.steps = []CertRotationStep{
 			&testStep{"step1", nil},


### PR DESCRIPTION
This change allows cert rotations to integrate with our device gateway's update events to produce something like:
```
$ fioctl devices updates og-qemu-hsm
ID                                        TIME                  VERSION  TARGET
--                                        ----                  -------  ------
certs-1668446396                          2022-11-14T17:19:58Z  282      intel-corei7-64-lmp-282
282-43ad1cd7-0228-431f-85b0-da5757ff5705  2022-11-14T17:19:44Z  282      intel-corei7-64-lmp-282

[doanac@xps15 fioconfig]$ fioctl devices updates og-qemu-hsm certs-1668446396
2022-11-14T17:19:56+00:00 : CertRotationStarted(intel-corei7-64-lmp-282) -> Succeed
2022-11-14T17:19:56+00:00 : Generate new certificate(intel-corei7-64-lmp-282) -> Succeed
2022-11-14T17:19:57+00:00 : Lock device configuration on server(intel-corei7-64-lmp-282) -> Succeed
2022-11-14T17:19:57+00:00 : Update local configuration with new key(intel-corei7-64-lmp-282) -> Succeed
2022-11-14T17:19:57+00:00 : Update device specific configuration on server with new key(intel-corei7-64-lmp-282) -> Succeed
2022-11-14T17:19:58+00:00 : Finalize aktualizr configuration(intel-corei7-64-lmp-282) -> Succeed
2022-11-14T17:19:58+00:00 : CertRotationCompleted(intel-corei7-64-lmp-282) -> Succeed
```