### PR TITLE
contrib: Add retries to renew-client-cert

### DIFF
--- a/contrib/renew-client-cert
+++ b/contrib/renew-client-cert
@@ -39,7 +39,10 @@ rotate() {
 	if [ -n "$cert_ids" ]; then
 		extra_args="$extra_args --pkcs11-cert-ids=$cert_ids"
 	fi
-	exec $fioconfig -c $SOTA_DIR renew-cert $extra_args $est_server $rotation_id 
+	if ! $fioconfig -c $SOTA_DIR renew-cert $extra_args $est_server $rotation_id  ; then
+		exit 123
+	fi
+	exit 0
 }
 
 # We'll execute under two conditions:

--- a/internal/app.go
+++ b/internal/app.go
@@ -18,6 +18,8 @@ import (
 	toml "github.com/pelletier/go-toml"
 )
 
+const onChangedForceExit = 123
+
 var NotModifiedError = errors.New("Config unchanged on server")
 
 // Functions to be called when the daemon is initialized
@@ -304,8 +306,8 @@ func (a *App) runOnChanged(fname string, fullpath string, onChanged []string) {
 			if err := cmd.Run(); err != nil {
 				log.Printf("Unable to run command: %v", err)
 				if exitError, ok := err.(*exec.ExitError); ok {
-					if exitError.ExitCode() == 123 {
-						a.exitFunc(123)
+					if exitError.ExitCode() == onChangedForceExit {
+						a.exitFunc(onChangedForceExit)
 					}
 				}
 			}

--- a/internal/app_test.go
+++ b/internal/app_test.go
@@ -236,7 +236,7 @@ func TestSafeHandler(t *testing.T) {
 func TestHandlerExit(t *testing.T) {
 	tmpDir := t.TempDir()
 	failScript := filepath.Join(tmpDir, "fail.sh")
-	script := "#!/bin/sh -e\necho failing with 123\nexit 123"
+	script := fmt.Sprintf("#!/bin/sh -e\necho failing with %d\nexit %d", onChangedForceExit, onChangedForceExit)
 	os.WriteFile(failScript, []byte(script), 0o755)
 
 	called := false


### PR DESCRIPTION
The `fioconfig renew-cert` command itself has retry logic. However, if that logic fails, fioconfig will carry along and never complete a rotation.

This change adds an even bigger retry loop around that process and will finally restart fioconfig if that fails. This will hopefully cause enough restarts that between systemd and fioconfig, things will finally get re-run to completion.

Signed-off-by: Andy Doan <andy@foundries.io>