### PR TITLE
Don't fail on corrupted config.encrypted file

### DIFF
--- a/internal/app.go
+++ b/internal/app.go
@@ -339,8 +339,7 @@ func (a *App) checkin(client *http.Client, crypto CryptoHandler) error {
 		if config.prev, err = UnmarshallFile(nil, a.EncryptedConfig, false); err != nil {
 			var perr *os.PathError
 			if !errors.As(err, &perr) || !os.IsNotExist(perr) {
-				log.Printf("Unable to load previous config version: %s", err)
-				return err
+				log.Printf("Unable to load previous config version: %s. Will overwrite", err)
 			}
 		}
 


### PR DESCRIPTION
The current logic has a bug that can more or less "brick" fioconfig:

 * echo "not valid json" > /var/sota/config.encrypted
 * daemon will not be able to process new config changes