### PR TITLE
Refactor: extract the generic state machine into base types

### DIFF
--- a/internal/rotate.go
+++ b/internal/rotate.go
@@ -1,17 +1,7 @@
 package internal
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
 	"log"
-	"net/http"
-	"os"
-	"path/filepath"
-	"time"
-
-	"github.com/coreos/go-systemd/v22/dbus"
 )
 
 type CertRotationState struct {
@@ -35,121 +25,28 @@ type CertRotationState struct {
 	Finalized bool
 }
 
-type CertRotationHandler struct {
-	State     CertRotationState
-	stateFile string
-	app       *App
-	client    *http.Client
-	crypto    *EciesCrypto
-	eventSync EventSync
-	steps     []CertRotationStep
-	cienv     bool
-}
-
-type CertRotationStep interface {
-	Name() string
-	Execute(handler *CertRotationHandler) error
-}
-
 // NewCertRotationHandler constructs a new handler to initiate a rotation with
 func NewCertRotationHandler(app *App, stateFile, estServer string) *CertRotationHandler {
-	eventUrl := app.sota.GetOrDie("tls.server") + "/events"
-
-	target, err := LoadCurrentTarget(filepath.Join(app.StorageDir, "current-target"))
-	if err != nil {
-		log.Printf("Unable to parse current-target. Events posted to server will be missing content: %s", err)
+	state := CertRotationState{EstServer: estServer}
+	steps := []CertRotationStep{
+		&estStep{},
+		&lockStep{},
+		&fullCfgStep{},
+		&deviceCfgStep{},
+		&finalizeStep{},
 	}
-
-	client, crypto := createClient(app.sota)
-	return &CertRotationHandler{
-		State:     CertRotationState{EstServer: estServer},
-		stateFile: stateFile,
-		app:       app,
-		client:    client,
-		crypto:    crypto.(*EciesCrypto),
-		eventSync: &DgEventSync{
-			client: client,
-			url:    eventUrl,
-			target: target,
-		},
-		steps: []CertRotationStep{
-			&estStep{},
-			&lockStep{},
-			&fullCfgStep{},
-			&deviceCfgStep{},
-			&finalizeStep{},
-		},
-	}
+	return newCertRotationHandler(app, stateFile, state, steps)
 }
 
 // RestoreCertRotationHandler will attempt to load a previous rotation attempt's
 // state and return a handler that can process it. This function returns nil when
 // `stateFile` does not exist
 func RestoreCertRotationHandler(app *App, stateFile string) *CertRotationHandler {
-	bytes, err := os.ReadFile(stateFile)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil
-		} else {
-			// Looks like we started a rotation, we should try and finish it
-			log.Printf("Error reading %s, return empty rotation state: %s", stateFile, err)
-		}
-	}
-	handler := NewCertRotationHandler(app, stateFile, "")
-	if err = json.Unmarshal(bytes, &handler.State); err != nil {
-		log.Printf("Error unmarshalling rotation state, return empty rotation state %s", err)
-		return handler
-	}
-	return handler
-}
-
-func (h *CertRotationHandler) Save() error {
-	bytes, err := json.Marshal(h.State)
-	if err != nil {
-		return err
-	}
-	return safeWrite(h.stateFile, bytes)
+	return restoreCertRotationHandler(app, stateFile)
 }
 
 func (h *CertRotationHandler) Rotate() error {
-	if len(h.State.RotationId) == 0 {
-		h.State.RotationId = fmt.Sprintf("certs-%d", time.Now().Unix())
-		log.Printf("Setting default rotation id to: %s", h.State.RotationId)
-	}
-	h.eventSync.SetCorrelationId(h.State.RotationId)
-	var err error
-	defer h.eventSync.NotifyCompleted(err)
-	h.eventSync.NotifyStarted()
-
-	// Before we even start - we should save our initial state (ie EstServer)
-	// and also make sure we *can* save our state.
-	if err = h.Save(); err != nil {
-		return fmt.Errorf("Unable to save initial state: %w", err)
-	}
-	for idx, step := range h.steps {
-		if idx < h.State.StepIdx {
-			log.Printf("Step already completed: %s", step.Name())
-		} else {
-			log.Printf("Executing step: %s", step.Name())
-			if err = step.Execute(h); err != nil {
-				h.eventSync.NotifyStep(step.Name(), err)
-				return err
-			}
-			h.State.StepIdx += 1
-			h.eventSync.NotifyStep(step.Name(), nil)
-			if err = h.Save(); err != nil {
-				return fmt.Errorf("Unable to save state: %w", err)
-			}
-		}
-	}
-	err = os.Rename(h.stateFile, h.stateFile+".completed")
-
-	// restart aklite and fioconfig *after* being "complete". Otherwise,
-	// we could wind up in a loop of: try-to-complete-rotation,
-	// restart-ourself-before marking complete
-	h.RestartServices()
-
-	return err
+	return h.execute()
 }
 
 // ResumeRotation checks if we have an incomplete cert rotation. If so, it
@@ -178,37 +75,4 @@ func (h *CertRotationHandler) ResumeRotation(online bool) error {
 	}
 	log.Print("Incomplete certificate rotation state found. Will attempt to complete")
 	return h.Rotate()
-}
-
-// useHsm detects if the handler should work with local files or PKCS11
-func (h *CertRotationHandler) usePkcs11() bool {
-	return h.crypto.ctx != nil
-}
-
-func (h *CertRotationHandler) RestartServices() {
-	if h.cienv {
-		fmt.Println("Skipping systemctl restarts for CI")
-		return
-	}
-
-	ctx := context.Background()
-	con, err := dbus.NewSystemConnectionContext(ctx)
-	if err != nil {
-		log.Fatalf("Unable to connect to DBUS for service restarts: %s", err)
-	}
-
-	for _, svc := range []string{"aktualizr-lite.service", "fioconfig.service"} {
-		restartChan := make(chan string)
-		_, err = con.RestartUnitContext(ctx, svc, "replace", restartChan)
-		if err != nil {
-			log.Fatalf("Unable to restart: %s, %s", svc, err)
-		}
-		result := <-restartChan
-		switch result {
-		case "done":
-			continue
-		default:
-			log.Fatalf("Error restarting %s: %s", svc, result)
-		}
-	}
 }

--- a/internal/rotate.go
+++ b/internal/rotate.go
@@ -46,7 +46,7 @@ func RestoreCertRotationHandler(app *App, stateFile string) *CertRotationHandler
 }
 
 func (h *CertRotationHandler) Rotate() error {
-	return h.execute("CertRotationStarted", "CertRotationCompleted")
+	return h.execute("CertRotationStarted", "CertRotationCompleted", true)
 }
 
 // ResumeRotation checks if we have an incomplete cert rotation. If so, it

--- a/internal/rotate.go
+++ b/internal/rotate.go
@@ -46,7 +46,7 @@ func RestoreCertRotationHandler(app *App, stateFile string) *CertRotationHandler
 }
 
 func (h *CertRotationHandler) Rotate() error {
-	return h.execute()
+	return h.execute("CertRotationStarted", "CertRotationCompleted")
 }
 
 // ResumeRotation checks if we have an incomplete cert rotation. If so, it

--- a/internal/rotate_config.go
+++ b/internal/rotate_config.go
@@ -16,7 +16,7 @@ func (s fullCfgStep) Name() string {
 	return "Update local configuration with new key"
 }
 
-func (s fullCfgStep) Execute(handler *CertRotationHandler) error {
+func (s fullCfgStep) Execute(handler *certRotationContext) error {
 	crypto, err := getCryptoHandler(handler)
 	if err != nil {
 		return err
@@ -44,7 +44,7 @@ func (s deviceCfgStep) Name() string {
 	return "Update device specific configuration on server with new key"
 }
 
-func (s deviceCfgStep) Execute(handler *CertRotationHandler) error {
+func (s deviceCfgStep) Execute(handler *certRotationContext) error {
 	// Load the new crypto handler
 	crypto, err := getCryptoHandler(handler)
 	if err != nil {
@@ -132,7 +132,7 @@ func encryptConfig(crypto *EciesCrypto, config map[string]*ConfigFile) ([]byte, 
 	return val, nil
 }
 
-func getCryptoHandler(h *CertRotationHandler) (*EciesCrypto, error) {
+func getCryptoHandler(h *certRotationContext) (*EciesCrypto, error) {
 	if !h.usePkcs11() {
 		block, _ := pem.Decode([]byte(h.State.NewKey))
 		key, err := x509.ParseECPrivateKey(block.Bytes)

--- a/internal/rotate_est.go
+++ b/internal/rotate_est.go
@@ -36,7 +36,7 @@ func (s estStep) Name() string {
 	return "Generate new certificate"
 }
 
-func (s estStep) Execute(handler *CertRotationHandler) error {
+func (s estStep) Execute(handler *certRotationContext) error {
 	// Find the current certificate so we can build the proper EST request
 	tlsCert := handler.client.Transport.(*http.Transport).TLSClientConfig.Certificates[0]
 	cert, err := x509.ParseCertificate(tlsCert.Certificate[0])
@@ -129,7 +129,7 @@ func (s estStep) Execute(handler *CertRotationHandler) error {
 	return nil
 }
 
-func (s estStep) nextPkeyId(handler *CertRotationHandler) string {
+func (s estStep) nextPkeyId(handler *certRotationContext) string {
 	cur := handler.app.sota.GetOrDie("p11.tls_pkey_id")
 	for _, val := range handler.State.PkeySlotIds {
 		if val != cur {
@@ -140,7 +140,7 @@ func (s estStep) nextPkeyId(handler *CertRotationHandler) string {
 	return "07"
 }
 
-func (s estStep) nextCertId(handler *CertRotationHandler) string {
+func (s estStep) nextCertId(handler *certRotationContext) string {
 	cur := handler.app.sota.GetOrDie("p11.tls_clientcert_id")
 	for _, val := range handler.State.CertSlotIds {
 		if val != cur {

--- a/internal/rotate_events.go
+++ b/internal/rotate_events.go
@@ -12,18 +12,14 @@ import (
 // EventSync in an interface for sending events to device-gateway. The abstraction
 // makes it easier to write unit tests
 type EventSync interface {
-	NotifyStarted()
-	NotifyStep(name string, err error)
-	NotifyCompleted(err error)
+	Notify(name string, err error)
 	SetCorrelationId(corId string)
 }
 
 type NoOpEventSync struct{}
 
-func (s NoOpEventSync) NotifyStarted()                    {}
-func (s NoOpEventSync) NotifyCompleted(err error)         {}
-func (s NoOpEventSync) NotifyStep(name string, err error) {}
-func (s NoOpEventSync) SetCorrelationId(corId string)     {}
+func (s NoOpEventSync) Notify(name string, err error) {}
+func (s NoOpEventSync) SetCorrelationId(corId string) {}
 
 type DgEventSync struct {
 	client        *http.Client
@@ -35,16 +31,7 @@ type DgEventSync struct {
 func (s *DgEventSync) SetCorrelationId(corId string) {
 	s.correlationId = corId
 }
-func (s *DgEventSync) NotifyStarted() {
-	s.notify("CertRotationStarted", nil)
-}
-func (s *DgEventSync) NotifyCompleted(err error) {
-	s.notify("CertRotationCompleted", err)
-}
-func (s *DgEventSync) NotifyStep(name string, err error) {
-	s.notify(name, err)
-}
-func (s *DgEventSync) notify(event string, err error) {
+func (s *DgEventSync) Notify(event string, err error) {
 	details := ""
 	if err != nil {
 		details = err.Error()

--- a/internal/rotate_finalize.go
+++ b/internal/rotate_finalize.go
@@ -12,7 +12,7 @@ func (s finalizeStep) Name() string {
 	return "Finalize aktualizr configuration"
 }
 
-func (s finalizeStep) Execute(handler *CertRotationHandler) error {
+func (s finalizeStep) Execute(handler *certRotationContext) error {
 	storagePath := handler.app.StorageDir
 	keyvals := make(map[string]string)
 	if handler.usePkcs11() {

--- a/internal/rotate_lock.go
+++ b/internal/rotate_lock.go
@@ -16,7 +16,7 @@ func (s lockStep) Name() string {
 	return "Lock device configuration on server"
 }
 
-func (s lockStep) Execute(handler *CertRotationHandler) error {
+func (s lockStep) Execute(handler *certRotationContext) error {
 	crypto, err := getCryptoHandler(handler)
 	if err != nil {
 		return err

--- a/internal/state.go
+++ b/internal/state.go
@@ -1,0 +1,157 @@
+package internal
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/coreos/go-systemd/v22/dbus"
+)
+
+type CertRotationHandler struct {
+	State     CertRotationState
+	stateFile string
+	app       *App
+	client    *http.Client
+	crypto    *EciesCrypto
+	eventSync EventSync
+	steps     []CertRotationStep
+	cienv     bool
+}
+
+type CertRotationStep interface {
+	Name() string
+	Execute(handler *CertRotationHandler) error
+}
+
+func newCertRotationHandler(
+	app *App, stateFile string, state CertRotationState, steps []CertRotationStep,
+) *CertRotationHandler {
+	eventUrl := app.sota.GetOrDie("tls.server") + "/events"
+
+	target, err := LoadCurrentTarget(filepath.Join(app.StorageDir, "current-target"))
+	if err != nil {
+		log.Printf("Unable to parse current-target. Events posted to server will be missing content: %s", err)
+	}
+
+	client, crypto := createClient(app.sota)
+	return &CertRotationHandler{
+		State:     state,
+		stateFile: stateFile,
+		app:       app,
+		client:    client,
+		crypto:    crypto.(*EciesCrypto),
+		steps:     steps,
+		eventSync: &DgEventSync{
+			client: client,
+			url:    eventUrl,
+			target: target,
+		},
+	}
+}
+
+// usePkcs11 detects if the handler should work with local files or PKCS11
+func (h *CertRotationHandler) usePkcs11() bool {
+	return h.crypto.ctx != nil
+}
+
+func (h *CertRotationHandler) Save() error {
+	bytes, err := json.Marshal(h.State)
+	if err != nil {
+		return err
+	}
+	return safeWrite(h.stateFile, bytes)
+}
+
+func restoreCertRotationHandler(app *App, stateFile string) *CertRotationHandler {
+	bytes, err := os.ReadFile(stateFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		} else {
+			// Looks like we started a rotation, we should try and finish it
+			log.Printf("Error reading %s, return empty rotation state: %s", stateFile, err)
+		}
+	}
+	handler := NewCertRotationHandler(app, stateFile, "")
+	if err = json.Unmarshal(bytes, &handler.State); err != nil {
+		log.Printf("Error unmarshalling rotation state, return empty rotation state %s", err)
+		return handler
+	}
+	return handler
+}
+
+func (h *CertRotationHandler) execute() error {
+	if len(h.State.RotationId) == 0 {
+		h.State.RotationId = fmt.Sprintf("certs-%d", time.Now().Unix())
+		log.Printf("Setting default rotation id to: %s", h.State.RotationId)
+	}
+	h.eventSync.SetCorrelationId(h.State.RotationId)
+	var err error
+	defer h.eventSync.NotifyCompleted(err)
+	h.eventSync.NotifyStarted()
+
+	// Before we even start - we should save our initial state (ie EstServer)
+	// and also make sure we *can* save our state.
+	if err = h.Save(); err != nil {
+		return fmt.Errorf("Unable to save initial state: %w", err)
+	}
+	for idx, step := range h.steps {
+		if idx < h.State.StepIdx {
+			log.Printf("Step already completed: %s", step.Name())
+		} else {
+			log.Printf("Executing step: %s", step.Name())
+			if err = step.Execute(h); err != nil {
+				h.eventSync.NotifyStep(step.Name(), err)
+				return err
+			}
+			h.State.StepIdx += 1
+			h.eventSync.NotifyStep(step.Name(), nil)
+			if err = h.Save(); err != nil {
+				return fmt.Errorf("Unable to save state: %w", err)
+			}
+		}
+	}
+	err = os.Rename(h.stateFile, h.stateFile+".completed")
+
+	// restart aklite and fioconfig *after* being "complete". Otherwise,
+	// we could wind up in a loop of: try-to-complete-rotation,
+	// restart-ourself-before marking complete
+	h.RestartServices()
+
+	return err
+}
+
+func (h *CertRotationHandler) RestartServices() {
+	if h.cienv {
+		fmt.Println("Skipping systemctl restarts for CI")
+		return
+	}
+
+	ctx := context.Background()
+	con, err := dbus.NewSystemConnectionContext(ctx)
+	if err != nil {
+		log.Fatalf("Unable to connect to DBUS for service restarts: %s", err)
+	}
+
+	for _, svc := range []string{"aktualizr-lite.service", "fioconfig.service"} {
+		restartChan := make(chan string)
+		_, err = con.RestartUnitContext(ctx, svc, "replace", restartChan)
+		if err != nil {
+			log.Fatalf("Unable to restart: %s, %s", svc, err)
+		}
+		result := <-restartChan
+		switch result {
+		case "done":
+			continue
+		default:
+			log.Fatalf("Error restarting %s: %s", svc, result)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ func renewCert(c *cli.Context) error {
 	handler.State.CertSlotIds = strings.Split(idsStr, ",")
 
 	if c.NArg() == 2 {
-		handler.State.RotationId = c.Args().Get(1)
+		handler.State.CorrelationId = c.Args().Get(1)
 	}
 
 	log.Printf("Performing certificate renewal")


### PR DESCRIPTION
I need to re-use a major part of renew-cert for the renew-root logic. Trying to do this in a truly reusable way comes with some pitfalls. This one uses generics.
It looks more nuanced, but comes with a more clear interface. Besides, it is more Golang-ish.