### PR TITLE
Fix: client rotation fails when there is no config

### DIFF
--- a/internal/rotate_config.go
+++ b/internal/rotate_config.go
@@ -4,8 +4,10 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/ThalesIgnite/crypto11"
 )
@@ -26,6 +28,9 @@ func (s fullCfgStep) Execute(handler *certRotationContext) error {
 	// Open/decrypt full config with current key
 	config, err := UnmarshallFile(handler.crypto, handler.app.EncryptedConfig, true)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) { // os.IsNotExist does not work on wrapped errors
+			return nil
+		}
 		return fmt.Errorf("Unable open current encrypted config: %w", err)
 	}
 

--- a/internal/rotate_finalize.go
+++ b/internal/rotate_finalize.go
@@ -46,9 +46,11 @@ func (s finalizeStep) Execute(handler *certRotationContext) error {
 		return err
 	}
 
-	path := filepath.Join(storagePath, "config.encrypted")
-	if err := safeWrite(path, []byte(handler.State.FullConfigEncrypted)); err != nil {
-		return fmt.Errorf("Error updating config.encrypted: %w", err)
+	if len(handler.State.FullConfigEncrypted) > 0 {
+		path := filepath.Join(storagePath, "config.encrypted")
+		if err := safeWrite(path, []byte(handler.State.FullConfigEncrypted)); err != nil {
+			return fmt.Errorf("Error updating config.encrypted: %w", err)
+		}
 	}
 	handler.State.Finalized = true
 	return nil


### PR DESCRIPTION
This is an edge case as the client cert rotation is usually triggered via a config.
But, in some cases a user might want to run renew-client-cert manually.
If there is no config.encrypted file, this would fail.