### PR TITLE
contrib: Do not restart aklite service if it is not enabled

### DIFF
--- a/contrib/aktualizr-toml-update
+++ b/contrib/aktualizr-toml-update
@@ -48,4 +48,6 @@ else
 	fi
 fi
 
-systemctl restart ${SOTA_CLIENT}
+if systemctl is-enabled --quiet ${SOTA_CLIENT} ; then
+	systemctl restart ${SOTA_CLIENT}
+fi


### PR DESCRIPTION
This facilitates the use of fioconfig when a custom OTA solution that requires the aklite daemon to be stopped is in use.