### PR TITLE
Move transport and sota config logic to packages

### DIFF
--- a/internal/app.go
+++ b/internal/app.go
@@ -211,7 +211,7 @@ func (a *App) checkin(client *http.Client, crypto CryptoHandler) error {
 		headers["If-Modified-Since"] = ts
 	}
 
-	res, err := httpGet(client, a.configUrl, headers)
+	res, err := transport.HttpGet(client, a.configUrl, headers)
 	if err != nil {
 		return err // Unable to attempt request
 	}

--- a/internal/app.go
+++ b/internal/app.go
@@ -59,20 +59,6 @@ func tomlAssertVal(cfg *sotatoml.AppConfig, key string, allowed []string) string
 	return val
 }
 
-// sota.toml has slot id's as "01". We need to turn that into []byte{1}
-func idToBytes(id string) []byte {
-	bytes := []byte(id)
-	start := -1
-	for idx, char := range bytes {
-		bytes[idx] = char - byte('0')
-		if bytes[idx] != 0 && start == -1 {
-			start = idx
-		}
-	}
-	//strip off leading 0's
-	return bytes[start:]
-}
-
 func createClientPkcs11(sota *sotatoml.AppConfig) (*http.Client, CryptoHandler) {
 	module := sota.GetOrDie("p11.module")
 	pin := sota.GetOrDie("p11.pass")
@@ -92,11 +78,11 @@ func createClientPkcs11(sota *sotatoml.AppConfig) (*http.Client, CryptoHandler) 
 		log.Fatal(err)
 	}
 
-	privKey, err := ctx.FindKeyPair(idToBytes(pkeyId), nil)
+	privKey, err := ctx.FindKeyPair(sotatoml.IdToBytes(pkeyId), nil)
 	if err != nil {
 		log.Fatal(err)
 	}
-	cert, err := ctx.FindCertificate(idToBytes(certId), nil, nil)
+	cert, err := ctx.FindCertificate(sotatoml.IdToBytes(certId), nil, nil)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/config.go
+++ b/internal/config.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/foundriesio/fioconfig/transport"
 )
 
 var Commit string
@@ -96,7 +98,7 @@ func updateConfig(app *App, client *http.Client, pubkey string) error {
 			},
 		},
 	}
-	res, err := httpPatch(client, app.configUrl, ccr)
+	res, err := transport.HttpPatch(client, app.configUrl, ccr)
 	if err != nil {
 		return err
 	}

--- a/internal/ecies.go
+++ b/internal/ecies.go
@@ -49,7 +49,7 @@ func (ec *EciesCrypto) Close() {
 	}
 }
 
-func NewEciesPkcs11Handler(ctx *crypto11.Context, privKey crypto11.Signer) CryptoHandler {
+func NewEciesPkcs11Handler(ctx *crypto11.Context, privKey crypto.PrivateKey) CryptoHandler {
 	return &EciesCrypto{ImportPcks11(ctx, privKey), ctx}
 }
 

--- a/internal/http_test.go
+++ b/internal/http_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/foundriesio/fioconfig/transport"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,7 +19,7 @@ func TestHttpRetry(t *testing.T) {
 
 	testWrapper(t, doGet, func(app *App, client *http.Client, tempdir string) {
 		start := time.Now()
-		res, err := httpGet(client, app.configUrl, nil)
+		res, err := transport.HttpGet(client, app.configUrl, nil)
 		elapsed := time.Since(start)
 		require.Nil(t, err)
 		require.Equal(t, 200, res.StatusCode)
@@ -28,7 +29,7 @@ func TestHttpRetry(t *testing.T) {
 		// Now do a test that won't retry:
 		codes = []int{400}
 		idx = 0
-		res, err = httpGet(client, app.configUrl, nil)
+		res, err = transport.HttpGet(client, app.configUrl, nil)
 		require.Nil(t, err)
 		require.Equal(t, 400, res.StatusCode)
 		require.Equal(t, 1, idx)

--- a/internal/rotate_config.go
+++ b/internal/rotate_config.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	"github.com/ThalesIgnite/crypto11"
+	"github.com/foundriesio/fioconfig/sotatoml"
 )
 
 type fullCfgStep struct{}
@@ -162,7 +163,7 @@ func getCryptoHandler(h *certRotationContext) (*EciesCrypto, error) {
 		return nil, fmt.Errorf("Unable to configure crypto11 library: %w", err)
 	}
 
-	privKey, err := ctx.FindKeyPair(idToBytes(h.State.NewKey), nil)
+	privKey, err := ctx.FindKeyPair(sotatoml.IdToBytes(h.State.NewKey), nil)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to find new HSM private key: %w", err)
 	}

--- a/internal/rotate_config.go
+++ b/internal/rotate_config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ThalesIgnite/crypto11"
 	"github.com/foundriesio/fioconfig/sotatoml"
+	"github.com/foundriesio/fioconfig/transport"
 )
 
 type fullCfgStep struct{}
@@ -66,7 +67,7 @@ func (s deviceCfgStep) Execute(handler *certRotationContext) error {
 
 	// Download/decrypt current device config with current key
 	url := handler.app.configUrl + "-device"
-	res, err := httpGet(handler.client, url, nil)
+	res, err := transport.HttpGet(handler.client, url, nil)
 	if err != nil {
 		return err
 	}
@@ -110,7 +111,7 @@ func (s deviceCfgStep) Execute(handler *certRotationContext) error {
 			OnChanged:   entry.OnChanged,
 		})
 	}
-	res, err = httpPatch(handler.client, handler.app.configUrl, ccr)
+	res, err = transport.HttpPatch(handler.client, handler.app.configUrl, ccr)
 	if err != nil {
 		return err
 	}

--- a/internal/rotate_est.go
+++ b/internal/rotate_est.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 
 	"github.com/ThalesIgnite/crypto11"
+	"github.com/foundriesio/fioconfig/sotatoml"
 	"github.com/miekg/pkcs11"
 	"go.mozilla.org/pkcs7"
 )
@@ -50,10 +51,10 @@ func (s estStep) Execute(handler *certRotationContext) error {
 	// Generate a new private key
 	if handler.usePkcs11() {
 		newKey = s.nextPkeyId(handler)
-		if err = handler.crypto.ctx.DeleteKeyPair(idToBytes(newKey), []byte("tls")); err != nil {
+		if err = handler.crypto.ctx.DeleteKeyPair(sotatoml.IdToBytes(newKey), []byte("tls")); err != nil {
 			return fmt.Errorf("Unable to free up slot(%s) for new keypair: %w", newKey, err)
 		}
-		pubAttr, err := crypto11.NewAttributeSetWithIDAndLabel(idToBytes(newKey), []byte("tls"))
+		pubAttr, err := crypto11.NewAttributeSetWithIDAndLabel(sotatoml.IdToBytes(newKey), []byte("tls"))
 		if err != nil {
 			return fmt.Errorf("Unable to define pkcs11 attributes for new key: %w", err)
 		}
@@ -114,10 +115,10 @@ func (s estStep) Execute(handler *certRotationContext) error {
 	// Update our state
 	if handler.usePkcs11() {
 		newCert := s.nextCertId(handler)
-		if err = handler.crypto.ctx.DeleteCertificate(idToBytes(newCert), nil, nil); err != nil {
+		if err = handler.crypto.ctx.DeleteCertificate(sotatoml.IdToBytes(newCert), nil, nil); err != nil {
 			return fmt.Errorf("Unable to free up slot(%s) for new cert: %w", newCert, err)
 		}
-		if err = handler.crypto.ctx.ImportCertificateWithLabel(idToBytes(newCert), []byte("client"), estCert); err != nil {
+		if err = handler.crypto.ctx.ImportCertificateWithLabel(sotatoml.IdToBytes(newCert), []byte("client"), estCert); err != nil {
 			return fmt.Errorf("Unable to import new cert into HSM: %w", err)
 		}
 		handler.State.NewCert = newCert

--- a/internal/rotate_events.go
+++ b/internal/rotate_events.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/foundriesio/fioconfig/transport"
 	"github.com/google/uuid"
 )
 
@@ -53,7 +54,7 @@ func (s *DgEventSync) Notify(event string, err error) {
 			},
 		},
 	}
-	res, err := httpPost(s.client, s.url, evt)
+	res, err := transport.HttpPost(s.client, s.url, evt)
 	if err != nil {
 		log.Printf("Unable to send event: %s", err)
 	} else if res.StatusCode < 200 || res.StatusCode > 204 {

--- a/internal/rotate_finalize.go
+++ b/internal/rotate_finalize.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/foundriesio/fioconfig/sotatoml"
 )
 
 type finalizeStep struct{}
@@ -42,13 +44,13 @@ func (s finalizeStep) Execute(handler *certRotationContext) error {
 			keyvals[pair[1]] = f.Name()
 		}
 	}
-	if err := handler.app.sota.updateKeys(keyvals); err != nil {
+	if err := handler.app.sota.UpdateKeys(keyvals); err != nil {
 		return err
 	}
 
 	if len(handler.State.FullConfigEncrypted) > 0 {
 		path := filepath.Join(storagePath, "config.encrypted")
-		if err := safeWrite(path, []byte(handler.State.FullConfigEncrypted)); err != nil {
+		if err := sotatoml.SafeWrite(path, []byte(handler.State.FullConfigEncrypted)); err != nil {
 			return fmt.Errorf("Error updating config.encrypted: %w", err)
 		}
 	}

--- a/internal/rotate_lock.go
+++ b/internal/rotate_lock.go
@@ -4,6 +4,8 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+
+	"github.com/foundriesio/fioconfig/transport"
 )
 
 type lockStep struct{}
@@ -32,7 +34,7 @@ func (s lockStep) Execute(handler *certRotationContext) error {
 	pubBytes = pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubBytes})
 
 	url := handler.app.sota.GetOrDie("tls.server") + "/device"
-	if res, err := httpPatch(handler.client, url, DeviceUpdate{string(pubBytes)}); err != nil {
+	if res, err := transport.HttpPatch(handler.client, url, DeviceUpdate{string(pubBytes)}); err != nil {
 		return err
 	} else if res.StatusCode != 200 {
 		return fmt.Errorf("Unable to set device's next public key: HTTP_%d - %s", res.StatusCode, res.String())

--- a/internal/rotate_test.go
+++ b/internal/rotate_test.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/foundriesio/fioconfig/sotatoml"
 	"github.com/stretchr/testify/require"
 	"go.mozilla.org/pkcs7"
 )
@@ -275,7 +276,7 @@ func TestRotateFinalize(t *testing.T) {
 		keyvals := map[string]string{
 			"storage.path": tmpdir,
 		}
-		require.Nil(t, app.sota.updateKeys(keyvals))
+		require.Nil(t, app.sota.UpdateKeys(keyvals))
 
 		stateFile := filepath.Join(tmpdir, "rotate.state")
 		handler := NewCertRotationHandler(app, stateFile, "est-server-doesn't-matter")
@@ -285,7 +286,7 @@ func TestRotateFinalize(t *testing.T) {
 		step := finalizeStep{}
 		require.Nil(t, step.Execute(&handler.stateContext))
 
-		sota, err := NewAppConfig([]string{filepath.Join(tmpdir, "sota.toml")})
+		sota, err := sotatoml.NewAppConfig([]string{filepath.Join(tmpdir, "sota.toml")})
 		require.Nil(t, err)
 
 		bytes, err := os.ReadFile(sota.GetOrDie("import.tls_pkey_path"))

--- a/internal/state.go
+++ b/internal/state.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/coreos/go-systemd/v22/dbus"
+	"github.com/foundriesio/fioconfig/sotatoml"
 )
 
 type BaseState struct {
@@ -97,7 +98,7 @@ func (h *stateContext[T]) Save() error {
 	if err != nil {
 		return err
 	}
-	return safeWrite(h.stateFile, bytes)
+	return sotatoml.SafeWrite(h.stateFile, bytes)
 }
 
 func (h *stateContext[T]) Restore() (loaded bool) {

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/foundriesio/fioconfig/internal"
+	"github.com/foundriesio/fioconfig/sotatoml"
 	"github.com/urfave/cli/v2"
 )
 
@@ -116,7 +117,7 @@ func main() {
 			&cli.StringSliceFlag{
 				Name:    "config",
 				Aliases: []string{"c"},
-				Value:   cli.NewStringSlice(internal.DEF_CONFIG_ORDER...),
+				Value:   cli.NewStringSlice(sotatoml.DEF_CONFIG_ORDER...),
 				Usage:   "Aktualizr config paths",
 				EnvVars: []string{"SOTA_DIR"},
 			},

--- a/sotatoml/app_config.go
+++ b/sotatoml/app_config.go
@@ -173,3 +173,17 @@ func (c AppConfig) UpdateKeys(keyVals map[string]string) error {
 
 	return SafeWrite(cfgFile.path, bytes)
 }
+
+// sota.toml has slot id's as "01". We need to turn that into []byte{1}
+func IdToBytes(id string) []byte {
+	bytes := []byte(id)
+	start := -1
+	for idx, char := range bytes {
+		bytes[idx] = char - byte('0')
+		if bytes[idx] != 0 && start == -1 {
+			start = idx
+		}
+	}
+	//strip off leading 0's
+	return bytes[start:]
+}

--- a/sotatoml/app_config.go
+++ b/sotatoml/app_config.go
@@ -1,4 +1,4 @@
-package internal
+package sotatoml
 
 import (
 	"errors"
@@ -157,7 +157,7 @@ func (c AppConfig) findWritableFile(keyVals map[string]string) (*cfgFile, error)
 	return nil, ErrNoWritableFound
 }
 
-func (c AppConfig) updateKeys(keyVals map[string]string) error {
+func (c AppConfig) UpdateKeys(keyVals map[string]string) error {
 	cfgFile, err := c.findWritableFile(keyVals)
 	if err != nil {
 		return err
@@ -171,5 +171,5 @@ func (c AppConfig) updateKeys(keyVals map[string]string) error {
 		return err
 	}
 
-	return safeWrite(cfgFile.path, bytes)
+	return SafeWrite(cfgFile.path, bytes)
 }

--- a/sotatoml/app_config_test.go
+++ b/sotatoml/app_config_test.go
@@ -1,4 +1,4 @@
-package internal
+package sotatoml
 
 import (
 	"os"
@@ -45,7 +45,7 @@ key = "val"`
 	keyvals := map[string]string{
 		"main.foo": "written",
 	}
-	require.Nil(t, cfg.updateKeys(keyvals))
+	require.Nil(t, cfg.UpdateKeys(keyvals))
 
 	cfg2, err := NewAppConfig([]string{usrLib, varSota, etc})
 	require.Nil(t, err)
@@ -55,7 +55,7 @@ key = "val"`
 	keyvals = map[string]string{
 		"main.bar": "mainbar",
 	}
-	require.Nil(t, cfg.updateKeys(keyvals))
+	require.Nil(t, cfg.UpdateKeys(keyvals))
 
 	cfg2, err = NewAppConfig([]string{usrLib, varSota, etc})
 	require.Nil(t, err)
@@ -66,13 +66,13 @@ key = "val"`
 	keyvals = map[string]string{
 		"updates.key": "this must fail",
 	}
-	require.NotNil(t, cfg.updateKeys(keyvals))
+	require.NotNil(t, cfg.UpdateKeys(keyvals))
 
 	// We must reject a keyval that does not exist - this api is for *updates* only
 	keyvals = map[string]string{
 		"updates.not_exist": "this must fail",
 	}
-	err = cfg.updateKeys(keyvals)
+	err = cfg.UpdateKeys(keyvals)
 	require.NotNil(t, err)
 	require.Equal(t, ErrNoWritableFound, err)
 
@@ -86,7 +86,7 @@ key = "val"`
 	defer func() {
 		_ = os.Chmod(usrLib, 0o777)
 	}()
-	err = cfg2.updateKeys(keyvals)
+	err = cfg2.UpdateKeys(keyvals)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "unable to write to file:")
 
@@ -99,7 +99,7 @@ key = "val"`
 	cfg2, err = NewAppConfig([]string{varSota, usrLib})
 	require.Nil(t, err)
 	keyvals["main.usrlib"] = "this should work"
-	err = cfg2.updateKeys(keyvals)
+	err = cfg2.UpdateKeys(keyvals)
 	require.Nil(t, err)
 	cfg2, err = NewAppConfig([]string{varSota, usrLib})
 	require.Nil(t, err)

--- a/sotatoml/safewrite.go
+++ b/sotatoml/safewrite.go
@@ -1,0 +1,29 @@
+package sotatoml
+
+import (
+	"fmt"
+	"os"
+)
+
+// Do an atomic write to the file which prevents race conditions for a reader.
+// Don't worry about writer synchronization as there is only one writer to these files.
+func SafeWrite(name string, data []byte) error {
+	tmpfile := name + ".tmp"
+	f, err := os.OpenFile(tmpfile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o640)
+	if err != nil {
+		return fmt.Errorf("Unable to create %s: %w", name, err)
+	}
+	defer os.Remove(tmpfile)
+	_, err = f.Write(data)
+	if err1 := f.Sync(); err1 != nil && err == nil {
+		err = err1
+	}
+	if err1 := f.Close(); err1 != nil && err == nil {
+		err = err1
+	}
+
+	if err != nil {
+		return fmt.Errorf("Unable to create %s: %w", name, err)
+	}
+	return os.Rename(tmpfile, name)
+}

--- a/transport/http.go
+++ b/transport/http.go
@@ -1,4 +1,4 @@
-package internal
+package transport
 
 import (
 	"bytes"
@@ -22,6 +22,18 @@ func (res httpRes) Json(data interface{}) error {
 
 func (res httpRes) String() string {
 	return string(res.Body)
+}
+
+func HttpGet(client *http.Client, url string, headers map[string]string) (*httpRes, error) {
+	return httpDo(client, http.MethodGet, url, headers, nil)
+}
+
+func HttpPatch(client *http.Client, url string, data interface{}) (*httpRes, error) {
+	return httpDo(client, http.MethodPatch, url, nil, data)
+}
+
+func HttpPost(client *http.Client, url string, data interface{}) (*httpRes, error) {
+	return httpDo(client, http.MethodPost, url, nil, data)
 }
 
 func readResponse(r *http.Response) (*httpRes, error) {
@@ -79,16 +91,4 @@ func httpDo(client *http.Client, method, url string, headers map[string]string, 
 		}
 	}
 	return res, err
-}
-
-func httpGet(client *http.Client, url string, headers map[string]string) (*httpRes, error) {
-	return httpDo(client, http.MethodGet, url, headers, nil)
-}
-
-func httpPatch(client *http.Client, url string, data interface{}) (*httpRes, error) {
-	return httpDo(client, http.MethodPatch, url, nil, data)
-}
-
-func httpPost(client *http.Client, url string, data interface{}) (*httpRes, error) {
-	return httpDo(client, http.MethodPost, url, nil, data)
 }

--- a/transport/http.go
+++ b/transport/http.go
@@ -10,35 +10,35 @@ import (
 	"time"
 )
 
-type httpRes struct {
+type HttpRes struct {
 	StatusCode int
 	Body       []byte
 	Header     http.Header
 }
 
-func (res httpRes) Json(data interface{}) error {
+func (res HttpRes) Json(data interface{}) error {
 	return json.Unmarshal(res.Body, data)
 }
 
-func (res httpRes) String() string {
+func (res HttpRes) String() string {
 	return string(res.Body)
 }
 
-func HttpGet(client *http.Client, url string, headers map[string]string) (*httpRes, error) {
+func HttpGet(client *http.Client, url string, headers map[string]string) (*HttpRes, error) {
 	return httpDo(client, http.MethodGet, url, headers, nil)
 }
 
-func HttpPatch(client *http.Client, url string, data interface{}) (*httpRes, error) {
+func HttpPatch(client *http.Client, url string, data interface{}) (*HttpRes, error) {
 	return httpDo(client, http.MethodPatch, url, nil, data)
 }
 
-func HttpPost(client *http.Client, url string, data interface{}) (*httpRes, error) {
+func HttpPost(client *http.Client, url string, data interface{}) (*HttpRes, error) {
 	return httpDo(client, http.MethodPost, url, nil, data)
 }
 
-func readResponse(r *http.Response) (*httpRes, error) {
+func readResponse(r *http.Response) (*HttpRes, error) {
 	defer r.Body.Close()
-	res := &httpRes{
+	res := &HttpRes{
 		StatusCode: r.StatusCode,
 		Header:     r.Header,
 	}
@@ -50,7 +50,7 @@ func readResponse(r *http.Response) (*httpRes, error) {
 	return res, nil
 }
 
-func httpDoOnce(client *http.Client, method, url string, headers map[string]string, data interface{}) (*httpRes, error) {
+func httpDoOnce(client *http.Client, method, url string, headers map[string]string, data interface{}) (*HttpRes, error) {
 	var dataBytes []byte
 	if data != nil {
 		var err error
@@ -77,9 +77,9 @@ func httpDoOnce(client *http.Client, method, url string, headers map[string]stri
 	return readResponse(res)
 }
 
-func httpDo(client *http.Client, method, url string, headers map[string]string, data interface{}) (*httpRes, error) {
+func httpDo(client *http.Client, method, url string, headers map[string]string, data interface{}) (*HttpRes, error) {
 	var err error
-	var res *httpRes
+	var res *HttpRes
 	for _, delay := range []int{0, 1, 2, 5, 13, 30} {
 		if delay != 0 {
 			log.Printf("HTTP %s to %s failed, trying again in %d seconds", url, method, delay)

--- a/transport/http_client.go
+++ b/transport/http_client.go
@@ -1,0 +1,19 @@
+package transport
+
+import (
+	"net/http"
+
+	"log"
+	"time"
+
+	"github.com/foundriesio/fioconfig/sotatoml"
+)
+
+func CreateClient(cfg *sotatoml.AppConfig) (*http.Client) {
+	tlsCfg, _, err := GetTlsConfig(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+	transport := &http.Transport{TLSClientConfig: tlsCfg}
+	return &http.Client{Timeout: time.Second * 30, Transport: transport}
+}

--- a/transport/tls.go
+++ b/transport/tls.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/ThalesIgnite/crypto11"
-
 	"github.com/foundriesio/fioconfig/sotatoml"
 )
 
@@ -66,37 +64,3 @@ func loadCertLocal(cfg *sotatoml.AppConfig) (tls.Certificate, error) {
 	return tls.LoadX509KeyPair(certFile, keyFile)
 }
 
-func loadCertPkcs11(cfg *sotatoml.AppConfig) (*crypto11.Context, tls.Certificate, error) {
-	module := cfg.Get("p11.module")
-	pin := cfg.Get("p11.pass")
-	pkeyId := cfg.Get("p11.tls_pkey_id")
-	certId := cfg.Get("p11.tls_clientcert_id")
-	if len(module) == 0 || len(pin) == 0 || len(pkeyId) == 0 || len(certId) == 0 {
-		return nil, tls.Certificate{}, fmt.Errorf("missing required p11 configs for: module, pass, tls_pkey_id, and/or tls_clientcert_id")
-	}
-
-	c11 := crypto11.Config{
-		Path:        module,
-		TokenLabel:  cfg.GetDefault("p11.label", "aktualizr"),
-		Pin:         pin,
-		MaxSessions: 2,
-	}
-
-	ctx, err := crypto11.Configure(&c11)
-	if err != nil {
-		return nil, tls.Certificate{}, fmt.Errorf("unable to load crypto11 config: %w", err)
-	}
-
-	privKey, err := ctx.FindKeyPair(sotatoml.IdToBytes(pkeyId), nil)
-	if err != nil {
-		return nil, tls.Certificate{}, fmt.Errorf("unable to load pkcs11 private key: %w", err)
-	}
-	cert, err := ctx.FindCertificate(sotatoml.IdToBytes(certId), nil, nil)
-	if err != nil {
-		return nil, tls.Certificate{}, fmt.Errorf("unable to load pkcs11 client certificate: %w", err)
-	}
-	return ctx, tls.Certificate{
-		Certificate: [][]byte{cert.Raw},
-		PrivateKey:  privKey,
-	}, nil
-}

--- a/transport/tls.go
+++ b/transport/tls.go
@@ -1,0 +1,102 @@
+package transport
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+
+	"github.com/ThalesIgnite/crypto11"
+
+	"github.com/foundriesio/fioconfig/sotatoml"
+)
+
+func GetTlsConfig(cfg *sotatoml.AppConfig) (*tls.Config, interface{}, error) {
+	if val := cfg.Get("tls.ca_source"); val != "file" {
+		return nil, nil, fmt.Errorf("invalid tls.ca_source: %s", val)
+	}
+
+	caCertPool := x509.NewCertPool()
+	caFile := cfg.Get("import.tls_cacert_path")
+	if len(caFile) == 0 {
+		return nil, nil, fmt.Errorf("import.tls_cacert_path not configured")
+	}
+	caCert, err := os.ReadFile(caFile)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to read CA cert: %w", err)
+	}
+	caCertPool.AppendCertsFromPEM(caCert)
+
+	tlsCfg := tls.Config{
+		Certificates: []tls.Certificate{},
+		RootCAs:      caCertPool,
+	}
+
+	var extra interface{}
+	source := cfg.Get("tls.pkey_source")
+	if source == "file" {
+		if cert, err := loadCertLocal(cfg); err == nil {
+			tlsCfg.Certificates = []tls.Certificate{cert}
+		} else {
+			return nil, nil, err
+		}
+	} else if source == "pkcs11" {
+		if ctx, cert, err := loadCertPkcs11(cfg); err == nil {
+			tlsCfg.Certificates = []tls.Certificate{cert}
+			extra = ctx
+		} else {
+			return nil, nil, err
+		}
+	} else {
+		return nil, nil, fmt.Errorf("invalid tls.pkey_source: %s", source)
+	}
+
+	return &tlsCfg, extra, nil
+}
+
+func loadCertLocal(cfg *sotatoml.AppConfig) (tls.Certificate, error) {
+	keyFile := cfg.Get("import.tls_pkey_path")
+	certFile := cfg.Get("import.tls_clientcert_path")
+	if len(keyFile) == 0 {
+		return tls.Certificate{}, fmt.Errorf("import.tls_pkey_path not specified")
+	}
+	if len(certFile) == 0 {
+		return tls.Certificate{}, fmt.Errorf("import.tls_clientcert_path not specified")
+	}
+	return tls.LoadX509KeyPair(certFile, keyFile)
+}
+
+func loadCertPkcs11(cfg *sotatoml.AppConfig) (*crypto11.Context, tls.Certificate, error) {
+	module := cfg.Get("p11.module")
+	pin := cfg.Get("p11.pass")
+	pkeyId := cfg.Get("p11.tls_pkey_id")
+	certId := cfg.Get("p11.tls_clientcert_id")
+	if len(module) == 0 || len(pin) == 0 || len(pkeyId) == 0 || len(certId) == 0 {
+		return nil, tls.Certificate{}, fmt.Errorf("missing required p11 configs for: module, pass, tls_pkey_id, and/or tls_clientcert_id")
+	}
+
+	c11 := crypto11.Config{
+		Path:        module,
+		TokenLabel:  cfg.GetDefault("p11.label", "aktualizr"),
+		Pin:         pin,
+		MaxSessions: 2,
+	}
+
+	ctx, err := crypto11.Configure(&c11)
+	if err != nil {
+		return nil, tls.Certificate{}, fmt.Errorf("unable to load crypto11 config: %w", err)
+	}
+
+	privKey, err := ctx.FindKeyPair(sotatoml.IdToBytes(pkeyId), nil)
+	if err != nil {
+		return nil, tls.Certificate{}, fmt.Errorf("unable to load pkcs11 private key: %w", err)
+	}
+	cert, err := ctx.FindCertificate(sotatoml.IdToBytes(certId), nil, nil)
+	if err != nil {
+		return nil, tls.Certificate{}, fmt.Errorf("unable to load pkcs11 client certificate: %w", err)
+	}
+	return ctx, tls.Certificate{
+		Certificate: [][]byte{cert.Raw},
+		PrivateKey:  privKey,
+	}, nil
+}

--- a/transport/tls_no_pkcs11.go
+++ b/transport/tls_no_pkcs11.go
@@ -1,0 +1,18 @@
+//go:build disable_pkcs11
+
+package transport
+
+import (
+	"crypto/tls"
+	"fmt"
+	"os"
+
+	"github.com/foundriesio/fioconfig/sotatoml"
+)
+
+
+func loadCertPkcs11(cfg *sotatoml.AppConfig) (*interface{}, tls.Certificate, error) {
+	fmt.Println("ERROR: PKCS#11 is not supported")
+	os.Exit(1)
+	return nil, tls.Certificate{}, nil
+}

--- a/transport/tls_pkcs11.go
+++ b/transport/tls_pkcs11.go
@@ -1,0 +1,48 @@
+//go:build !disable_pkcs11
+
+package transport
+
+import (
+	"crypto/tls"
+	"fmt"
+
+	"github.com/ThalesIgnite/crypto11"
+
+	"github.com/foundriesio/fioconfig/sotatoml"
+)
+
+
+func loadCertPkcs11(cfg *sotatoml.AppConfig) (*crypto11.Context, tls.Certificate, error) {
+	module := cfg.Get("p11.module")
+	pin := cfg.Get("p11.pass")
+	pkeyId := cfg.Get("p11.tls_pkey_id")
+	certId := cfg.Get("p11.tls_clientcert_id")
+	if len(module) == 0 || len(pin) == 0 || len(pkeyId) == 0 || len(certId) == 0 {
+		return nil, tls.Certificate{}, fmt.Errorf("missing required p11 configs for: module, pass, tls_pkey_id, and/or tls_clientcert_id")
+	}
+
+	c11 := crypto11.Config{
+		Path:        module,
+		TokenLabel:  cfg.GetDefault("p11.label", "aktualizr"),
+		Pin:         pin,
+		MaxSessions: 2,
+	}
+
+	ctx, err := crypto11.Configure(&c11)
+	if err != nil {
+		return nil, tls.Certificate{}, fmt.Errorf("unable to load crypto11 config: %w", err)
+	}
+
+	privKey, err := ctx.FindKeyPair(sotatoml.IdToBytes(pkeyId), nil)
+	if err != nil {
+		return nil, tls.Certificate{}, fmt.Errorf("unable to load pkcs11 private key: %w", err)
+	}
+	cert, err := ctx.FindCertificate(sotatoml.IdToBytes(certId), nil, nil)
+	if err != nil {
+		return nil, tls.Certificate{}, fmt.Errorf("unable to load pkcs11 client certificate: %w", err)
+	}
+	return ctx, tls.Certificate{
+		Certificate: [][]byte{cert.Raw},
+		PrivateKey:  privKey,
+	}, nil
+}


### PR DESCRIPTION
This allows config toml parsing and device gateway communication features to be used in other golang tools, like the experimental update client hosted at https://github.com/foundriesio/fiotuf

---

@doanac I haven't changed your 3 patches, just rebased them and added a few more changes of my own as separate patches. Let us know if there anything you believe is not ready for merge yet.