### PR TITLE
Tiny improvements

### DIFF
--- a/sotatoml/app_config.go
+++ b/sotatoml/app_config.go
@@ -65,7 +65,7 @@ func NewAppConfig(configPaths []string) (*AppConfig, error) {
 	for _, cfg := range keys {
 		cfg.tree, err = toml.LoadFile(cfg.path)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to load %s; err: %w", cfg.path, err)
 		}
 	}
 

--- a/transport/http_client.go
+++ b/transport/http_client.go
@@ -3,17 +3,16 @@ package transport
 import (
 	"net/http"
 
-	"log"
 	"time"
 
 	"github.com/foundriesio/fioconfig/sotatoml"
 )
 
-func CreateClient(cfg *sotatoml.AppConfig) (*http.Client) {
+func CreateClient(cfg *sotatoml.AppConfig) (*http.Client, error) {
 	tlsCfg, _, err := GetTlsConfig(cfg)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	transport := &http.Transport{TLSClientConfig: tlsCfg}
-	return &http.Client{Timeout: time.Second * 30, Transport: transport}
+	return &http.Client{Timeout: time.Second * 30, Transport: transport}, nil
 }


### PR DESCRIPTION
- Specify .toml file path in the error context if parsing error occurs.
- Don't exit if an error occurs during the http client creation, return the error instead.