### PR TITLE
app_config: Add method to check if key exists

### DIFF
--- a/sotatoml/app_config.go
+++ b/sotatoml/app_config.go
@@ -73,6 +73,15 @@ func NewAppConfig(configPaths []string) (*AppConfig, error) {
 	return &cfg, nil
 }
 
+func (c AppConfig) Has(key string) bool {
+	for i := range c.cfgs {
+		if c.cfgs[i].tree.Has(key) {
+			return true
+		}
+	}
+	return false
+}
+
 func (c AppConfig) Get(key string) string {
 	for i := range c.cfgs {
 		val := c.cfgs[i].tree.GetDefault(key, "").(string)


### PR DESCRIPTION
Add a method to `AppConfig` to check whether a specified key exists in the TOML-based app configuration.
This allows `fioup` to differentiate between cases where compose_apps is not set (meaning all apps should be considered for updates) and cases where compose_apps is explicitly set to `""` or `","`.