### PR TITLE
http: Allow client to set user agent and content type

### DIFF
--- a/transport/http.go
+++ b/transport/http.go
@@ -68,10 +68,14 @@ func httpDoOnce(client *http.Client, method, url string, headers map[string]stri
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Add("User-Agent", "fioconfig-client/2")
-	req.Header.Add("Content-Type", "application/json")
 	for k, v := range headers {
 		req.Header.Add(k, v)
+	}
+	if req.Header.Get("User-Agent") == "" {
+		req.Header.Add("User-Agent", "fioconfig-client/2")
+	}
+	if req.Header.Get("Content-Type") == "" {
+		req.Header.Add("Content-Type", "application/json")
 	}
 	req.Close = true
 


### PR DESCRIPTION
If an external utility uses this package then it makes sense to allow the utility to set the user-agent header value, as well as content type. If a client doesn't set those headers then the default one are set.