### PR TITLE
fiotest: Update the way we set the test "target"

### DIFF
--- a/fiotest/api.go
+++ b/fiotest/api.go
@@ -25,16 +25,14 @@ func NewApi(client *http.Client, fiotestUrl string) *Api {
 }
 
 func (a Api) Create(name, testId string) (*Test, error) {
-	// Hard-coded to group all tests by the same Target in the backend
-	headers := map[string]string{"x-ats-target": "fiocofig-action"}
-
 	type testbody struct {
 		Name   string `json:"name"`
+		Target string `json:"target"`
 		TestId string `json:"test-id"`
 	}
-	body := testbody{Name: name, TestId: testId}
+	body := testbody{Name: name, Target: "fioconfig-action", TestId: testId}
 
-	res, err := transport.HttpDo(a.client, http.MethodPost, a.baseUrl, headers, body)
+	res, err := transport.HttpDo(a.client, http.MethodPost, a.baseUrl, nil, body)
 	if err != nil {
 		return nil, err
 	} else if res.StatusCode != 201 {


### PR DESCRIPTION
When we run remote-actions we must set a "target" to use the fiotest backend APIs. However, by setting x-ats-target, the device gateway may update the device's actual target name while fiotest is running leading to confusion.

The device gateway was changed to allow a target name to be set in the test body to work around this.